### PR TITLE
Update player-list role visuals and add regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run",
 		"lint": "prettier --check .",
 		"format": "prettier --write ."
 	},
@@ -25,7 +26,8 @@
 		"svelte-icons": "^2.1.0",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.3",
-		"vite": "^6.3.3"
+		"vite": "^6.3.3",
+		"vitest": "^4.0.18"
 	},
 	"type": "module",
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       vite:
         specifier: ^6.3.3
         version: 6.3.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
 packages:
 
@@ -234,6 +237,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -340,6 +346,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.5':
     resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
     peerDependencies:
@@ -379,11 +388,46 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
@@ -394,6 +438,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -401,6 +449,10 @@ packages:
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -433,6 +485,9 @@ packages:
   devalue@5.1.1:
     resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild@0.25.3:
     resolution: {integrity: sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==}
     engines: {node: '>=18'}
@@ -444,6 +499,13 @@ packages:
   esrap@1.4.6:
     resolution: {integrity: sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
@@ -454,6 +516,15 @@ packages:
 
   fdir@6.4.4:
     resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -485,6 +556,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -501,11 +575,21 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   postcss@8.5.3:
@@ -539,6 +623,9 @@ packages:
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
     engines: {node: '>=18'}
@@ -546,6 +633,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   svelte-check@4.1.4:
     resolution: {integrity: sha512-v0j7yLbT29MezzaQJPEDwksybTE2Ups9rUxEXy92T06TiA0cbqcO8wAOwNUVkFW6B0hsYHA+oAX3BS8b/2oHtw==}
@@ -565,9 +658,24 @@ packages:
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -631,6 +739,45 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   zimmerframe@1.1.2:
     resolution: {integrity: sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==}
@@ -736,6 +883,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -803,6 +952,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.0':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
     dependencies:
       acorn: 8.14.1
@@ -855,17 +1006,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.7': {}
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@6.3.3)':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.3
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   acorn@8.14.1: {}
 
   aria-query@5.3.2: {}
 
+  assertion-error@2.0.1: {}
+
   axobject-query@4.1.0: {}
 
   base64-arraybuffer@1.0.2: {}
+
+  chai@6.2.2: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -886,6 +1087,8 @@ snapshots:
   deepmerge@4.3.1: {}
 
   devalue@5.1.1: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.3:
     optionalDependencies:
@@ -921,6 +1124,12 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
+
+  expect-type@1.3.0: {}
+
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
@@ -928,6 +1137,10 @@ snapshots:
   fdir@6.4.4(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fsevents@2.3.3:
     optional: true
@@ -951,6 +1164,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -959,9 +1176,15 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  obug@2.1.1: {}
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   postcss@8.5.3:
     dependencies:
@@ -1010,6 +1233,8 @@ snapshots:
 
   set-cookie-parser@2.7.1: {}
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.1:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -1017,6 +1242,10 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   svelte-check@4.1.4(picomatch@4.0.2)(svelte@5.25.9)(typescript@5.7.3):
     dependencies:
@@ -1053,10 +1282,21 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.13:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   totalist@3.0.1: {}
 
@@ -1082,5 +1322,45 @@ snapshots:
   vitefu@1.0.5(vite@6.3.3):
     optionalDependencies:
       vite: 6.3.3
+
+  vitest@4.0.18:
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@6.3.3)
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.3.3
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zimmerframe@1.1.2: {}

--- a/src/lib/player_list_item.test.ts
+++ b/src/lib/player_list_item.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { Position } from "$lib/positions";
+import type { PlayerRecord } from "$lib/stores/player_store";
+import {
+	comparePlayersForPosition,
+	getSkillForPosition,
+	isSecondaryForPosition,
+} from "$lib/player_list_item";
+
+function player(
+	name: string,
+	role: "primary" | "secondary",
+	weight: number,
+	skill?: "low" | "mid" | "high",
+): PlayerRecord {
+	return {
+		name,
+		positions: [{ position: Position.CentreMid, role, weight, skill }],
+	};
+}
+
+describe("player_list_item", () => {
+	it("detects secondary role for a list position", () => {
+		expect(isSecondaryForPosition(player("A", "secondary", 1), Position.CentreMid)).toBe(true);
+		expect(isSecondaryForPosition(player("B", "primary", 1), Position.CentreMid)).toBe(false);
+	});
+
+	it("always treats primary role as high skill", () => {
+		expect(getSkillForPosition(player("A", "primary", 1, "low"), Position.CentreMid)).toBe("high");
+		expect(getSkillForPosition(player("B", "primary", 1), Position.CentreMid)).toBe("high");
+	});
+
+	it("uses configured skill for secondary role with mid fallback", () => {
+		expect(getSkillForPosition(player("A", "secondary", 1, "low"), Position.CentreMid)).toBe("low");
+		expect(getSkillForPosition(player("B", "secondary", 1, "high"), Position.CentreMid)).toBe("high");
+		expect(getSkillForPosition(player("C", "secondary", 1), Position.CentreMid)).toBe("mid");
+	});
+
+	it("sorts primary entries above secondary entries", () => {
+		const primary = player("A", "primary", 99);
+		const secondary = player("B", "secondary", 0);
+		expect(comparePlayersForPosition(primary, secondary, Position.CentreMid)).toBeLessThan(0);
+		expect(comparePlayersForPosition(secondary, primary, Position.CentreMid)).toBeGreaterThan(0);
+	});
+
+	it("sorts by weight within the same role group", () => {
+		const a = player("A", "secondary", 1);
+		const b = player("B", "secondary", 3);
+		expect(comparePlayersForPosition(a, b, Position.CentreMid)).toBeLessThan(0);
+		expect(comparePlayersForPosition(b, a, Position.CentreMid)).toBeGreaterThan(0);
+	});
+});

--- a/src/lib/player_list_item.ts
+++ b/src/lib/player_list_item.ts
@@ -1,0 +1,46 @@
+import type { Position } from "$lib/positions";
+import type { PlayerPosition, PlayerRecord } from "$lib/stores/player_store";
+
+export function getPositionForList(
+	player: PlayerRecord,
+	position: Position,
+): PlayerPosition | undefined {
+	return player.positions.find((pos) => pos.position === position);
+}
+
+export function isSecondaryForPosition(player: PlayerRecord, position: Position): boolean {
+	return getPositionForList(player, position)?.role === "secondary";
+}
+
+export function getSkillForPosition(
+	player: PlayerRecord,
+	position: Position,
+): "low" | "mid" | "high" {
+	if (!isSecondaryForPosition(player, position)) {
+		return "high";
+	}
+
+	const skill = getPositionForList(player, position)?.skill;
+	if (skill === "low" || skill === "high") {
+		return skill;
+	}
+	return "mid";
+}
+
+export function comparePlayersForPosition(
+	a: PlayerRecord,
+	b: PlayerRecord,
+	position: Position,
+): number {
+	const roleA = isSecondaryForPosition(a, position) ? 1 : 0;
+	const roleB = isSecondaryForPosition(b, position) ? 1 : 0;
+	if (roleA !== roleB) {
+		return roleA - roleB;
+	}
+
+	const positionA = getPositionForList(a, position);
+	const positionB = getPositionForList(b, position);
+	const weightA = positionA ? positionA.weight : Number.MAX_VALUE;
+	const weightB = positionB ? positionB.weight : Number.MAX_VALUE;
+	return weightA - weightB;
+}

--- a/src/routes/PlayerList.svelte
+++ b/src/routes/PlayerList.svelte
@@ -7,9 +7,15 @@
 	 */
 	import { type Position } from "$lib/positions";
 	import { getPositionSelectOptions } from "$lib/positions";
+	import {
+		comparePlayersForPosition,
+		getPositionForList,
+		getSkillForPosition,
+		isSecondaryForPosition,
+	} from "$lib/player_list_item";
 	import { getVisibleAssignedPosition } from "$lib/player_visibility";
 	import { formation } from "$lib/stores/formation_store";
-	import { players, removePlayer, updatePlayers } from "$lib/stores/player_store";
+	import { players, removePlayer, type PlayerRecord, updatePlayers } from "$lib/stores/player_store";
 	import PlayerEditModal from "./PlayerEditModal.svelte";
 	import { flip } from "svelte/animate";
 
@@ -26,18 +32,7 @@
 			}
 			return getVisibleAssignedPosition(player, visible_positions) === position;
 		})
-		.toSorted((a, b) => {
-			// Find the target position in player a
-			const positionA = a.positions.find((p) => p.position === position);
-			const weightA = positionA ? positionA.weight : Number.MAX_VALUE; // Fallback if position not found
-
-			// Find the target position in player b
-			const positionB = b.positions.find((p) => p.position === position);
-			const weightB = positionB ? positionB.weight : Number.MAX_VALUE; // Fallback if position not found
-
-			// Compare the weights
-			return weightA - weightB;
-		});
+		.toSorted((a, b) => comparePlayersForPosition(a, b, position));
 
 	let ghost: HTMLElement;
 	let grabbed: HTMLElement | null = null;
@@ -143,6 +138,30 @@
 		show_edit_modal = false;
 		editing_player_name = "";
 	}
+
+	function getListPosition(player: PlayerRecord) {
+		return getPositionForList(player, position);
+	}
+
+	function isSecondary(player: PlayerRecord): boolean {
+		return isSecondaryForPosition(player, position);
+	}
+
+	function getSkill(player: PlayerRecord): "low" | "mid" | "high" {
+		return getSkillForPosition(player, position);
+	}
+
+	function getSkillColor(skill: "low" | "mid" | "high"): string {
+		if (skill === "low") return "hsl(8 78% 56%)";
+		if (skill === "high") return "hsl(120 52% 45%)";
+		return "hsl(46 92% 54%)";
+	}
+
+	function getSkillFadeColor(skill: "low" | "mid" | "high"): string {
+		if (skill === "low") return "hsl(8 78% 56% / 0)";
+		if (skill === "high") return "hsl(120 52% 45% / 0)";
+		return "hsl(46 92% 54% / 0)";
+	}
 </script>
 
 <main class="dragdroplist">
@@ -183,9 +202,11 @@
 					? "grabbed"
 					: ""}
 				class="item"
+				class:item-secondary={isSecondary(player)}
 				data-index={i}
 				data-id={player.name ? player.name : JSON.stringify(player)}
 				data-grabY="0"
+				style={`--skill-color: ${getSkillColor(getSkill(player))}; --skill-fade-color: ${getSkillFadeColor(getSkill(player))};`}
 				on:mousedown={function (ev) {
 					grab(ev.clientY, ev.currentTarget as HTMLElement);
 				}}
@@ -235,7 +256,12 @@
 				</div>
 
 				<div class="content">
-					{player.name}
+					<span class="player-name">{player.name}</span>
+					{#if isSecondary(player)}
+						<span class="meta-row">
+							<span class="pill role-pill role-secondary">2nd</span>
+						</span>
+					{/if}
 				</div>
 
 				<div class="buttons actions">
@@ -298,6 +324,24 @@
 		border-radius: 10px;
 		padding: 0.15rem 0.25rem;
 		user-select: none;
+		position: relative;
+		overflow: hidden;
+		isolation: isolate;
+	}
+
+	.item::after {
+		content: "";
+		position: absolute;
+		inset: 0 0 0 auto;
+		width: 36%;
+		background: linear-gradient(90deg, var(--skill-fade-color) 0%, var(--skill-color) 100%);
+		opacity: 0.35;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.item.item-secondary::after {
+		opacity: 0.22;
 	}
 
 	.item:last-child {
@@ -310,6 +354,46 @@
 
 	.item > * {
 		margin: auto;
+		position: relative;
+		z-index: 1;
+	}
+
+	.content {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.15rem;
+		padding: 0.1rem 0.25rem;
+	}
+
+	.player-name {
+		font-weight: 600;
+		line-height: 1.1;
+	}
+
+	.meta-row {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		flex-wrap: wrap;
+	}
+
+	.pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.05rem 0.4rem;
+		border-radius: 999px;
+		font-size: 0.68rem;
+		line-height: 1.15;
+		border: 1px solid transparent;
+		background: rgba(255, 255, 255, 0.75);
+	}
+
+	.role-pill.role-secondary {
+		border-color: rgba(30, 64, 175, 0.28);
+		color: #1e40af;
+		background: rgba(219, 234, 254, 0.9);
 	}
 
 	.buttons {
@@ -381,6 +465,10 @@
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+		}
+
+		.meta-row {
+			white-space: normal;
 		}
 	}
 </style>


### PR DESCRIPTION
## Summary
- update player list items to show secondary role with a compact 2nd pill
- keep skill represented via right-side gradient, with primary treated as high skill
- sort list rows so primary assignments appear above secondary assignments
- extract role/skill/sort behavior into src/lib/player_list_item.ts
- add vitest regression coverage for role detection, skill fallback, and ordering

## Validation
- pnpm test
- pnpm check