### PR TITLE
Add modal settings with persistent display toggles

### DIFF
--- a/src/lib/stores/settings_store.ts
+++ b/src/lib/stores/settings_store.ts
@@ -1,0 +1,44 @@
+import { browser } from "$app/environment";
+import { writable } from "svelte/store";
+
+export type AppSettings = {
+	show_skill_gradient: boolean;
+	show_secondary_positions: boolean;
+};
+
+const default_value: AppSettings = {
+	show_skill_gradient: true,
+	show_secondary_positions: false,
+};
+
+const initial_value = loadInitialValue();
+export const settings = writable<AppSettings>(initial_value);
+
+settings.subscribe((value) => {
+	if (!browser) {
+		return;
+	}
+	window.localStorage.setItem("app_settings", JSON.stringify(value));
+});
+
+function loadInitialValue(): AppSettings {
+	if (!browser) {
+		return default_value;
+	}
+
+	const stored_data = window.localStorage.getItem("app_settings");
+	if (!stored_data) {
+		return default_value;
+	}
+
+	try {
+		const parsed = JSON.parse(stored_data) as Partial<AppSettings>;
+		return {
+			show_skill_gradient: parsed.show_skill_gradient ?? default_value.show_skill_gradient,
+			show_secondary_positions:
+				parsed.show_secondary_positions ?? default_value.show_secondary_positions,
+		};
+	} catch {
+		return default_value;
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,17 @@
 <script lang="ts">
 	import "../styles.css";
+	import SettingsModal from "./SettingsModal.svelte";
 
 	const currentYear = new Date().getFullYear();
+	let show_settings_modal = false;
+
+	function openSettingsModal(): void {
+		show_settings_modal = true;
+	}
+
+	function closeSettingsModal(): void {
+		show_settings_modal = false;
+	}
 </script>
 
 <svelte:head>
@@ -14,6 +24,19 @@
 
 		<div class="header-controls">
 			<a href="/how-to-use" class="help-link">How to Use</a>
+			<button
+				type="button"
+				class="settings-link"
+				aria-label="Settings"
+				title="Settings"
+				on:click={openSettingsModal}
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
+					<path
+						d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.28 7.28 0 0 0-1.63-.94l-.36-2.54A.5.5 0 0 0 13.9 2h-3.8a.5.5 0 0 0-.49.42l-.36 2.54c-.58.22-1.13.54-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.71 8.48a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32a.5.5 0 0 0 .6.22l2.39-.96c.5.4 1.05.72 1.63.94l.36 2.54a.5.5 0 0 0 .49.42h3.8a.5.5 0 0 0 .49-.42l.36-2.54c.58-.22 1.13-.54 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58zM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7z"
+					/>
+				</svg>
+			</button>
 		</div>
 	</div>
 </header>
@@ -22,17 +45,17 @@
 
 <footer>
 	<div id="footer-content">
-		<span>&copy; {currentYear} Niko Bentley</span>
-		<ul>
-			<li><a href="/how-to-use" class="help-link">How to Use the App</a></li>
-			<li>
-				<a href="https://github.com/MapleThunder/depth-chart-sv" class="help-link">
-					Source on Github
-				</a>
-			</li>
-		</ul>
+		<span>
+			&copy; {currentYear}
+			<a href="http://CodBodDesigns.ca" target="_blank" rel="noopener noreferrer">
+				Cod Bod Designs
+			</a>
+		</span>
+		<a href="/how-to-use" class="help-link">How to Use the App</a>
 	</div>
 </footer>
+
+<SettingsModal open={show_settings_modal} on:close={closeSettingsModal} />
 
 <style>
 	header,
@@ -63,6 +86,27 @@
 		display: flex;
 		gap: 1rem;
 		align-items: center;
+	}
+
+	.settings-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		border: none;
+		background: transparent;
+		color: var(--text-light);
+		transition: color 0.2s ease;
+	}
+
+	.settings-link svg {
+		display: block;
+		fill: currentColor;
+	}
+
+	.settings-link:hover,
+	.settings-link:focus {
+		color: var(--accent);
 	}
 
 	a {
@@ -99,9 +143,10 @@
 		width: 100%;
 		height: 100%;
 		display: flex;
-		flex-direction: column;
+		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+		gap: clamp(1rem, 2rem, 4rem);
 	}
 
 	#footer-content > ul {
@@ -120,6 +165,10 @@
 	@media screen and (max-width: 700px) {
 		div.header-content {
 			padding: 0 5px;
+		}
+
+		#footer-content {
+			flex-direction: column;
 		}
 
 		a#home-link {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import FormationSelect from "./FormationSelect.svelte";
 	import SharePictureButton from "./SharePictureButton.svelte";
 	import ClearAllButton from "./ClearAllButton.svelte";
+	import { settings } from "$lib/stores/settings_store";
 
 	let positions: PositionData[];
 	$: $formation, (positions = getPositionsForFormation($formation));
@@ -18,7 +19,6 @@
 	$: unassigned_players = $players
 		.filter((player) => getVisibleAssignedPosition(player, visible_positions) === undefined)
 		.toSorted((a, b) => a.name.localeCompare(b.name));
-	let show_secondary_positions = false;
 
 	let show_hidden_edit_modal = false;
 	let editing_hidden_player_name = "";
@@ -56,14 +56,6 @@
 		<div class="form-wrapper">
 			<FormationSelect />
 			<PlayerEntryForm />
-
-			<div class="secondary-visibility">
-				<label class="switch">
-					<input type="checkbox" bind:checked={show_secondary_positions} />
-					<span class="slider" aria-hidden="true"></span>
-				</label>
-				<span>Show secondary positions</span>
-			</div>
 
 			<hr />
 
@@ -103,7 +95,7 @@
 
 	<div id="position-boxes" class="position-boxes">
 		{#each positions as positionData}
-			<PositionBox {positionData} {show_secondary_positions} />
+			<PositionBox positionData={positionData} show_secondary_positions={$settings.show_secondary_positions} />
 		{/each}
 	</div>
 </div>
@@ -138,61 +130,6 @@
 		border-radius: var(--border-radius);
 		border: var(--border);
 		box-shadow: var(--panel-shadow-soft);
-	}
-
-	.secondary-visibility {
-		margin-top: 0.7rem;
-		display: flex;
-		align-items: center;
-		gap: 0.6rem;
-		font-size: 0.9rem;
-		color: hsl(210, 15%, 30%);
-		font-weight: 600;
-	}
-
-	.switch {
-		position: relative;
-		display: inline-flex;
-		width: 42px;
-		height: 24px;
-	}
-
-	.switch input {
-		opacity: 0;
-		width: 0;
-		height: 0;
-	}
-
-	.slider {
-		position: absolute;
-		cursor: pointer;
-		inset: 0;
-		background-color: hsl(210, 20%, 90%);
-		border-radius: 999px;
-		transition: background-color 0.2s ease;
-		border: 1px solid var(--panel-border);
-	}
-
-	.slider::before {
-		content: "";
-		position: absolute;
-		height: 18px;
-		width: 18px;
-		left: 3px;
-		top: 50%;
-		transform: translateY(-50%);
-		background-color: var(--white);
-		border-radius: 50%;
-		transition: transform 0.2s ease;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
-	}
-
-	.switch input:checked + .slider {
-		background-color: var(--primary);
-	}
-
-	.switch input:checked + .slider::before {
-		transform: translate(18px, -50%);
 	}
 
 	.button-wrapper {

--- a/src/routes/PlayerEditModal.svelte
+++ b/src/routes/PlayerEditModal.svelte
@@ -308,6 +308,7 @@
 		border: var(--border);
 		border-radius: var(--border-radius);
 		box-shadow: var(--panel-shadow-soft);
+		overflow: hidden;
 	}
 
 	.modal-header {
@@ -315,7 +316,16 @@
 		justify-content: space-between;
 		align-items: center;
 		padding: 0.8rem 1rem 0.4rem;
-		border-bottom: var(--border);
+		border-radius: var(--border-radius) var(--border-radius) 0 0;
+		border-bottom: 1px solid color-mix(in srgb, var(--primary) 80%, #000 20%);
+		background:
+			linear-gradient(
+				135deg,
+				color-mix(in srgb, color-mix(in srgb, var(--primary), #000 8%) 80%, transparent),
+				color-mix(in srgb, var(--primary) 80%, transparent)
+			),
+			linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 70%);
+		color: var(--text-light);
 	}
 
 	.modal-header h3 {
@@ -324,13 +334,20 @@
 	}
 
 	.modal-close {
-		background: transparent;
-		border: 1px solid transparent;
+		background: rgba(255, 255, 255, 0.12);
+		border: 1px solid rgba(255, 255, 255, 0.25);
 		font-size: 1.3rem;
 		line-height: 1;
 		padding: 0.1rem 0.4rem;
 		border-radius: 999px;
 		cursor: pointer;
+		color: var(--text-light);
+	}
+
+	.modal-close:hover,
+	.modal-close:focus {
+		background: rgba(255, 255, 255, 0.24);
+		border-color: rgba(255, 255, 255, 0.35);
 	}
 
 	.modal-body {

--- a/src/routes/PlayerList.svelte
+++ b/src/routes/PlayerList.svelte
@@ -16,6 +16,7 @@
 	import { getVisibleAssignedPosition } from "$lib/player_visibility";
 	import { formation } from "$lib/stores/formation_store";
 	import { players, removePlayer, type PlayerRecord, updatePlayers } from "$lib/stores/player_store";
+	import { settings } from "$lib/stores/settings_store";
 	import PlayerEditModal from "./PlayerEditModal.svelte";
 	import { flip } from "svelte/animate";
 
@@ -203,6 +204,7 @@
 					: ""}
 				class="item"
 				class:item-secondary={isSecondary(player)}
+				class:item-has-skill-gradient={$settings.show_skill_gradient}
 				data-index={i}
 				data-id={player.name ? player.name : JSON.stringify(player)}
 				data-grabY="0"
@@ -335,12 +337,16 @@
 		inset: 0 0 0 auto;
 		width: 36%;
 		background: linear-gradient(90deg, var(--skill-fade-color) 0%, var(--skill-color) 100%);
-		opacity: 0.35;
+		opacity: 0;
 		pointer-events: none;
 		z-index: 0;
 	}
 
-	.item.item-secondary::after {
+	.item.item-has-skill-gradient::after {
+		opacity: 0.35;
+	}
+
+	.item.item-secondary.item-has-skill-gradient::after {
 		opacity: 0.22;
 	}
 

--- a/src/routes/SettingsModal.svelte
+++ b/src/routes/SettingsModal.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+	import { createEventDispatcher } from "svelte";
+	import { settings, type AppSettings } from "$lib/stores/settings_store";
+
+	export let open = false;
+
+	const dispatch = createEventDispatcher<{ close: void }>();
+
+	function close(): void {
+		dispatch("close");
+	}
+
+	function updateSetting<K extends keyof AppSettings>(key: K, value: AppSettings[K]): void {
+		settings.update((current) => ({ ...current, [key]: value }));
+	}
+</script>
+
+{#if open}
+	<div
+		class="modal-backdrop"
+		role="button"
+		tabindex="0"
+		aria-label="Close settings modal"
+		on:click={close}
+		on:keydown={(ev) => {
+			if (ev.key === "Escape" || ev.key === "Enter" || ev.key === " ") {
+				ev.preventDefault();
+				close();
+			}
+		}}
+	>
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Settings"
+			tabindex="-1"
+			on:click|stopPropagation
+			on:keydown|stopPropagation={() => {}}
+		>
+			<header class="modal-header">
+				<h2>Settings</h2>
+				<button class="modal-close" aria-label="Close settings" on:click={close}>×</button>
+			</header>
+			<div class="modal-body">
+				<label class="setting-row" for="show-skill-gradient">
+					<div>
+						<span class="setting-title">Player Skill Colour Gradient</span>
+						<span class="setting-copy">Show the right-side colour gradient on player rows.</span>
+					</div>
+					<span class="switch">
+						<input
+							id="show-skill-gradient"
+							type="checkbox"
+							checked={$settings.show_skill_gradient}
+							on:change={(event) => {
+								const target = event.currentTarget as HTMLInputElement;
+								updateSetting("show_skill_gradient", target.checked);
+							}}
+						/>
+						<span class="slider" aria-hidden="true"></span>
+					</span>
+				</label>
+
+				<label class="setting-row" for="show-secondary-positions">
+					<div>
+						<span class="setting-title">Show Secondary Positions</span>
+						<span class="setting-copy"
+							>Display players in their secondary roles on the depth chart.</span
+						>
+					</div>
+					<span class="switch">
+						<input
+							id="show-secondary-positions"
+							type="checkbox"
+							checked={$settings.show_secondary_positions}
+							on:change={(event) => {
+								const target = event.currentTarget as HTMLInputElement;
+								updateSetting("show_secondary_positions", target.checked);
+							}}
+						/>
+						<span class="slider" aria-hidden="true"></span>
+					</span>
+				</label>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		background: rgba(10, 12, 16, 0.55);
+		display: grid;
+		place-items: center;
+		padding: 1rem;
+	}
+
+	.modal {
+		width: min(560px, 100%);
+		max-height: 90vh;
+		overflow: auto;
+		background: var(--paper);
+		border: var(--border);
+		border-radius: var(--border-radius);
+		box-shadow: 0 24px 52px rgba(0, 0, 0, 0.25);
+		overflow: hidden;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.9rem 1rem;
+		border-radius: var(--border-radius) var(--border-radius) 0 0;
+		border-bottom: 1px solid color-mix(in srgb, var(--primary) 80%, #000 20%);
+		background:
+			linear-gradient(
+				135deg,
+				color-mix(in srgb, color-mix(in srgb, var(--primary), #000 8%) 80%, transparent),
+				color-mix(in srgb, var(--primary) 80%, transparent)
+			),
+			linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 70%);
+		color: var(--text-light);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.2rem;
+	}
+
+	.modal-close {
+		font-size: 1.3rem;
+		line-height: 1;
+		width: 32px;
+		height: 32px;
+		border: 1px solid rgba(255, 255, 255, 0.25);
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.12);
+		color: var(--text-light);
+	}
+
+	.modal-close:hover,
+	.modal-close:focus {
+		background: rgba(255, 255, 255, 0.24);
+		border-color: rgba(255, 255, 255, 0.35);
+	}
+
+	.modal-body {
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.setting-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.setting-title {
+		display: block;
+		font-weight: 600;
+	}
+
+	.setting-copy {
+		display: block;
+		font-size: 0.9rem;
+		color: hsl(210, 14%, 38%);
+	}
+
+	.switch {
+		position: relative;
+		display: inline-flex;
+		width: 42px;
+		height: 24px;
+	}
+
+	.switch input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+
+	.slider {
+		position: absolute;
+		cursor: pointer;
+		inset: 0;
+		background-color: hsl(210, 20%, 90%);
+		border-radius: 999px;
+		transition: background-color 0.2s ease;
+		border: 1px solid var(--panel-border);
+	}
+
+	.slider::before {
+		content: "";
+		position: absolute;
+		height: 18px;
+		width: 18px;
+		left: 3px;
+		top: 50%;
+		transform: translateY(-50%);
+		background-color: var(--white);
+		border-radius: 50%;
+		transition: transform 0.2s ease;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+	}
+
+	.switch input:checked + .slider {
+		background-color: var(--primary);
+	}
+
+	.switch input:checked + .slider::before {
+		transform: translate(18px, -50%);
+	}
+</style>

--- a/src/routes/how-to-use/+page.svelte
+++ b/src/routes/how-to-use/+page.svelte
@@ -23,8 +23,9 @@
 		</p>
 
 		<p>
-			Use the Show secondary positions toggle to include secondary roles in the lists. Depth totals
-			and header colours always use primary positions only.
+			Use the gear icon in the header to open Settings. From there you can turn on Show Secondary
+			Positions to include secondary roles in the lists, and toggle the Player Skill Colour Gradient
+			on or off. Depth totals and header colours always use primary positions only.
 		</p>
 
 		<h2>Depth & Colours</h2>


### PR DESCRIPTION
## Summary
- add a persistent app settings store for visual display preferences
- replace the standalone settings page with a global settings modal opened from the header gear icon
- add toggles for player skill gradient and secondary positions, and apply those settings in list rendering
- polish modal header styling and apply the same treatment to the player edit modal
- update the How To Use page to describe the new settings modal flow

## Validation
- pnpm check
- pnpm test