### PR TITLE
Add editable primary skill ranking and skill-first sorting

### DIFF
--- a/src/lib/player_list_item.ts
+++ b/src/lib/player_list_item.ts
@@ -16,15 +16,24 @@ export function getSkillForPosition(
 	player: PlayerRecord,
 	position: Position,
 ): "low" | "mid" | "high" {
-	if (!isSecondaryForPosition(player, position)) {
-		return "high";
-	}
-
-	const skill = getPositionForList(player, position)?.skill;
+	const list_position = getPositionForList(player, position);
+	const skill = list_position?.skill;
 	if (skill === "low" || skill === "high") {
 		return skill;
 	}
+	if (skill === "mid") {
+		return "mid";
+	}
+	if (list_position?.role === "primary") {
+		return "high";
+	}
 	return "mid";
+}
+
+function getSkillScore(skill: "low" | "mid" | "high"): number {
+	if (skill === "high") return 3;
+	if (skill === "mid") return 2;
+	return 1;
 }
 
 export function comparePlayersForPosition(
@@ -32,6 +41,12 @@ export function comparePlayersForPosition(
 	b: PlayerRecord,
 	position: Position,
 ): number {
+	const skill_a = getSkillScore(getSkillForPosition(a, position));
+	const skill_b = getSkillScore(getSkillForPosition(b, position));
+	if (skill_a !== skill_b) {
+		return skill_b - skill_a;
+	}
+
 	const roleA = isSecondaryForPosition(a, position) ? 1 : 0;
 	const roleB = isSecondaryForPosition(b, position) ? 1 : 0;
 	if (roleA !== roleB) {
@@ -42,5 +57,9 @@ export function comparePlayersForPosition(
 	const positionB = getPositionForList(b, position);
 	const weightA = positionA ? positionA.weight : Number.MAX_VALUE;
 	const weightB = positionB ? positionB.weight : Number.MAX_VALUE;
-	return weightA - weightB;
+	if (weightA !== weightB) {
+		return weightA - weightB;
+	}
+
+	return a.name.localeCompare(b.name);
 }

--- a/src/lib/stores/player_store.ts
+++ b/src/lib/stores/player_store.ts
@@ -16,6 +16,8 @@ export type PlayerRecord = {
 };
 
 const defaultValue: PlayerRecord[] = [];
+const PLAYER_STORE_VERSION = 2;
+const PLAYER_STORE_VERSION_KEY = "player_store_version";
 const initialValue = loadInitialValue();
 export const players = writable(initialValue);
 
@@ -23,6 +25,7 @@ export const players = writable(initialValue);
 const unsubscribeLocalStorage = players.subscribe((value) => {
 	if (browser) {
 		window.localStorage.setItem("player_store", JSON.stringify(value));
+		window.localStorage.setItem(PLAYER_STORE_VERSION_KEY, String(PLAYER_STORE_VERSION));
 	}
 });
 // onDestroy(unsubscribeLocalStorage);
@@ -34,14 +37,21 @@ function loadInitialValue(): PlayerRecord[] {
 	if (browser) {
 		const storedData = window.localStorage.getItem("player_store");
 		if (storedData) {
+			const stored_version = Number(window.localStorage.getItem(PLAYER_STORE_VERSION_KEY) ?? "0");
+			const migrate_legacy_primary_default = !Number.isFinite(stored_version) || stored_version < 2;
 			const parsed = JSON.parse(storedData) as PlayerRecord[];
-			return parsed.map((record) => normalizePlayerRecord(record));
+			return parsed.map((record) =>
+				normalizePlayerRecord(record, { migrate_legacy_primary_default }),
+			);
 		}
 	}
 	return defaultValue;
 }
 
-function normalizePositions(positions: PlayerPosition[]): PlayerPosition[] {
+function normalizePositions(
+	positions: PlayerPosition[],
+	options?: { migrate_legacy_primary_default?: boolean },
+): PlayerPosition[] {
 	if (positions.length === 0) {
 		return positions;
 	}
@@ -49,7 +59,7 @@ function normalizePositions(positions: PlayerPosition[]): PlayerPosition[] {
 	const normalized = positions.map((pos) => ({
 		...pos,
 		role: pos.role ?? "secondary",
-		skill: pos.skill === "medium" ? "mid" : (pos.skill ?? "mid"),
+		skill: pos.skill === "medium" ? "mid" : pos.skill,
 	}));
 
 	let primary_index = normalized.findIndex((pos) => pos.role === "primary");
@@ -64,13 +74,30 @@ function normalizePositions(positions: PlayerPosition[]): PlayerPosition[] {
 		}
 	});
 
+	normalized.forEach((pos) => {
+		if (pos.skill === "low" || pos.skill === "mid" || pos.skill === "high") {
+			if (
+				options?.migrate_legacy_primary_default &&
+				pos.role === "primary" &&
+				pos.skill === "mid"
+			) {
+				pos.skill = "high";
+			}
+			return;
+		}
+		pos.skill = pos.role === "primary" ? "high" : "mid";
+	});
+
 	return normalized;
 }
 
-function normalizePlayerRecord(record: PlayerRecord): PlayerRecord {
+function normalizePlayerRecord(
+	record: PlayerRecord,
+	options?: { migrate_legacy_primary_default?: boolean },
+): PlayerRecord {
 	return {
 		...record,
-		positions: normalizePositions(record.positions),
+		positions: normalizePositions(record.positions, options),
 	};
 }
 

--- a/src/routes/HowToUseContent.svelte
+++ b/src/routes/HowToUseContent.svelte
@@ -58,7 +58,7 @@
 			></path>
 		</svg> 
 		icon to edit a player, set
-		their primary position, and add secondary positions with a skill level (high, mid, or low). Click
+		their primary position, choose ability level (high, mid, or low), and add secondary positions. Click
 		the X to remove a player from a specific position. If a player has no remaining positions, they are
 		removed from the chart.
 	</p>

--- a/src/routes/PlayerEditModal.svelte
+++ b/src/routes/PlayerEditModal.svelte
@@ -11,6 +11,7 @@
 	const dispatch = createEventDispatcher<{ close: void }>();
 
 	let edit_primary_position: Position | undefined;
+	let edit_primary_skill: SkillLevel = "high";
 	let edit_secondary_positions: Position[] = [];
 	let edit_secondary_skills: Partial<Record<Position, SkillLevel>> = {};
 	let initialized_for_player = "";
@@ -48,6 +49,10 @@
 			existing_player.positions.find((pos) => pos.role === "primary") ??
 			existing_player.positions[0];
 		edit_primary_position = primary_position?.position;
+		edit_primary_skill =
+			primary_position?.skill === "low" || primary_position?.skill === "mid"
+				? primary_position.skill
+				: "high";
 		edit_secondary_positions = existing_player.positions
 			.filter((pos) => pos.position !== primary_position?.position)
 			.map((pos) => pos.position);
@@ -89,9 +94,7 @@
 				role: pos === edit_primary_position ? "primary" : "secondary",
 				skill:
 					pos === edit_primary_position
-						? existing_position?.skill === "medium"
-							? "mid"
-							: (existing_position?.skill ?? "mid")
+						? edit_primary_skill
 						: (edit_secondary_skills[pos] ??
 							(existing_position?.skill === "medium"
 								? "mid"
@@ -195,13 +198,36 @@
 				<button class="modal-close" aria-label="Close" on:click={close}>×</button>
 			</header>
 			<form class="modal-body" on:submit|preventDefault={save}>
-				<label for="edit_primary">Primary Position</label>
-				<select name="edit_primary" bind:value={edit_primary_position} disabled={!playerName}>
-					<option value="">Select a primary position</option>
-					{#each all_position_options as option}
-						<option value={option.value}>{option.label}</option>
-					{/each}
-				</select>
+				<div class="primary-header-row">
+					<label for="edit_primary">Primary Position</label>
+					<label for="edit_primary_skill">Skill</label>
+				</div>
+				<div class="primary-row">
+					<select
+						id="edit_primary"
+						class="position-select"
+						name="edit_primary"
+						bind:value={edit_primary_position}
+						disabled={!playerName}
+					>
+						<option value="">Select a primary position</option>
+						{#each all_position_options as option}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</select>
+					<select
+						id="edit_primary_skill"
+						class="skill-select"
+						name="edit_primary_skill"
+						bind:value={edit_primary_skill}
+						style={`--skill-color: ${getSkillColor(edit_primary_skill)}`}
+						disabled={!playerName}
+					>
+						<option value="high">High</option>
+						<option value="mid">Mid</option>
+						<option value="low">Low</option>
+					</select>
+				</div>
 
 				<div class="secondary-header">
 					<span class="secondary-title">Secondary Position(s)</span>
@@ -374,6 +400,28 @@
 		justify-content: space-between;
 		align-items: center;
 		gap: 0.6rem;
+	}
+
+	.primary-header-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: end;
+		gap: 0.7rem;
+	}
+
+	.primary-header-row label {
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-size: 0.75rem;
+		color: hsl(210, 12%, 40%);
+	}
+
+	.primary-row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+		gap: 0.7rem;
+		margin-bottom: 0.2rem;
 	}
 
 	.secondary-add {

--- a/tests/unit/lib/player_list_item.test.ts
+++ b/tests/unit/lib/player_list_item.test.ts
@@ -25,8 +25,8 @@ describe("player_list_item", () => {
 		expect(isSecondaryForPosition(player("B", "primary", 1), Position.CentreMid)).toBe(false);
 	});
 
-	it("always treats primary role as high skill", () => {
-		expect(getSkillForPosition(player("A", "primary", 1, "low"), Position.CentreMid)).toBe("high");
+	it("uses configured skill for primary role with high fallback", () => {
+		expect(getSkillForPosition(player("A", "primary", 1, "low"), Position.CentreMid)).toBe("low");
 		expect(getSkillForPosition(player("B", "primary", 1), Position.CentreMid)).toBe("high");
 	});
 
@@ -36,16 +36,30 @@ describe("player_list_item", () => {
 		expect(getSkillForPosition(player("C", "secondary", 1), Position.CentreMid)).toBe("mid");
 	});
 
-	it("sorts primary entries above secondary entries", () => {
-		const primary = player("A", "primary", 99);
-		const secondary = player("B", "secondary", 0);
+	it("sorts by skill before role", () => {
+		const primary_mid = player("A", "primary", 99, "mid");
+		const secondary_high = player("B", "secondary", 0, "high");
+		expect(comparePlayersForPosition(primary_mid, secondary_high, Position.CentreMid)).toBeGreaterThan(0);
+		expect(comparePlayersForPosition(secondary_high, primary_mid, Position.CentreMid)).toBeLessThan(0);
+	});
+
+	it("sorts primary entries above secondary entries when skills tie", () => {
+		const primary = player("A", "primary", 99, "mid");
+		const secondary = player("B", "secondary", 0, "mid");
 		expect(comparePlayersForPosition(primary, secondary, Position.CentreMid)).toBeLessThan(0);
 		expect(comparePlayersForPosition(secondary, primary, Position.CentreMid)).toBeGreaterThan(0);
 	});
 
-	it("sorts by weight within the same role group", () => {
+	it("sorts by weight within the same role and skill group", () => {
 		const a = player("A", "secondary", 1);
 		const b = player("B", "secondary", 3);
+		expect(comparePlayersForPosition(a, b, Position.CentreMid)).toBeLessThan(0);
+		expect(comparePlayersForPosition(b, a, Position.CentreMid)).toBeGreaterThan(0);
+	});
+
+	it("sorts by name when role, skill, and weight are equal", () => {
+		const a = player("Alex", "secondary", 1, "mid");
+		const b = player("Blair", "secondary", 1, "mid");
 		expect(comparePlayersForPosition(a, b, Position.CentreMid)).toBeLessThan(0);
 		expect(comparePlayersForPosition(b, a, Position.CentreMid)).toBeGreaterThan(0);
 	});

--- a/tests/unit/lib/stores/player_store.test.ts
+++ b/tests/unit/lib/stores/player_store.test.ts
@@ -29,6 +29,21 @@ describe("player_store", () => {
 		expect(alex.positions[0].role).toBe("primary");
 		expect(alex.positions[0].skill).toBe("mid");
 		expect(alex.positions[1].role).toBe("secondary");
+		expect(alex.positions[1].skill).toBe("mid");
+	});
+
+	it("defaults missing primary skill to high", () => {
+		addPlayer({
+			name: "Taylor",
+			positions: [
+				{ position: Position.LeftFullback, weight: 0, role: "primary" },
+				{ position: Position.CentreBack, weight: 1, role: "secondary", skill: "low" },
+			],
+		});
+
+		const [taylor] = get(players);
+		const primary = taylor.positions.find((pos) => pos.role === "primary");
+		expect(primary?.skill).toBe("high");
 	});
 
 	it("merges new positions for an existing player without duplicates", () => {

--- a/tests/unit/routes/PlayerEditModal.test.ts
+++ b/tests/unit/routes/PlayerEditModal.test.ts
@@ -49,4 +49,16 @@ describe("PlayerEditModal", () => {
 		expect(alex.positions[0].position).toBe(Position.CentreMid);
 		expect(alex.positions[0].role).toBe("primary");
 	});
+
+	it("updates the primary position skill", async () => {
+		seedPlayer([{ position: Position.CentreMid, weight: 2, role: "primary", skill: "high" }]);
+
+		render(PlayerEditModal, { open: true, playerName: "Alex" });
+		await userEvent.selectOptions(screen.getByRole("combobox", { name: "Skill" }), "mid");
+		await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		const [alex] = get(players);
+		const primary = alex.positions.find((pos) => pos.role === "primary");
+		expect(primary?.skill).toBe("mid");
+	});
 });


### PR DESCRIPTION
## Summary
- add primary skill editing in Player Edit modal and align its UI with secondary skill controls
- default primary skill to high during normalisation and migrate legacy local data defaults
- update sorting to rank by skill first, then primary before secondary, then weight/name
- update help copy to mention primary ability editing
- extend tests for comparator logic, store normalisation, and primary skill updates

## Validation
- pnpm test