### PR TITLE
Add selectable sort modes with manual ordering

### DIFF
--- a/src/lib/player_list_item.ts
+++ b/src/lib/player_list_item.ts
@@ -1,4 +1,5 @@
 import type { Position } from "$lib/positions";
+import type { PlayerSortMode } from "$lib/stores/settings_store";
 import type { PlayerPosition, PlayerRecord } from "$lib/stores/player_store";
 
 export function getPositionForList(
@@ -31,7 +32,17 @@ export function comparePlayersForPosition(
 	a: PlayerRecord,
 	b: PlayerRecord,
 	position: Position,
+	sort_mode: PlayerSortMode = "default",
 ): number {
+	if (sort_mode === "custom") {
+		const weightA = getPositionForList(a, position)?.weight ?? Number.MAX_VALUE;
+		const weightB = getPositionForList(b, position)?.weight ?? Number.MAX_VALUE;
+		if (weightA !== weightB) {
+			return weightA - weightB;
+		}
+		return a.name.localeCompare(b.name);
+	}
+
 	const roleA = isSecondaryForPosition(a, position) ? 1 : 0;
 	const roleB = isSecondaryForPosition(b, position) ? 1 : 0;
 	if (roleA !== roleB) {

--- a/src/lib/stores/settings_store.ts
+++ b/src/lib/stores/settings_store.ts
@@ -1,14 +1,18 @@
 import { browser } from "$app/environment";
 import { writable } from "svelte/store";
 
+export type PlayerSortMode = "default" | "custom";
+
 export type AppSettings = {
 	show_skill_gradient: boolean;
 	show_secondary_positions: boolean;
+	player_sort_mode: PlayerSortMode;
 };
 
 const default_value: AppSettings = {
 	show_skill_gradient: true,
 	show_secondary_positions: false,
+	player_sort_mode: "default",
 };
 
 const initial_value = loadInitialValue();
@@ -33,10 +37,16 @@ function loadInitialValue(): AppSettings {
 
 	try {
 		const parsed = JSON.parse(stored_data) as Partial<AppSettings>;
+		const parsed_sort_mode =
+			parsed.player_sort_mode === "custom" || parsed.player_sort_mode === "default"
+				? parsed.player_sort_mode
+				: default_value.player_sort_mode;
+
 		return {
 			show_skill_gradient: parsed.show_skill_gradient ?? default_value.show_skill_gradient,
 			show_secondary_positions:
 				parsed.show_secondary_positions ?? default_value.show_secondary_positions,
+			player_sort_mode: parsed_sort_mode,
 		};
 	} catch {
 		return default_value;

--- a/src/routes/HowToUseContent.svelte
+++ b/src/routes/HowToUseContent.svelte
@@ -50,32 +50,28 @@
 	</div>
 
 	<p>
-		Each position box shows players assigned to that role. Click the 
+		Each position box shows players assigned to that role. Click the
 		<svg xmlns="http://www.w3.org/2000/svg" height="12" viewBox="0 0 24 24" width="12">
 			<path d="M0 0h24v24H0z" fill="none"></path>
 			<path
 				d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zm18-11.5a.996.996 0 0 0 0-1.41l-2.59-2.59a.996.996 0 1 0-1.41 1.41l2.59 2.59c.39.39 1.02.39 1.41 0z"
 			></path>
-		</svg> 
-		icon to edit a player, set
-		their primary position, and add secondary positions with a skill level (high, mid, or low). Click
-		the X to remove a player from a specific position. If a player has no remaining positions, they are
-		removed from the chart.
+		</svg>
+		icon to edit a player, set their primary position, and add secondary positions with a skill level
+		(high, mid, or low). Click the X to remove a player from a specific position. If a player has no
+		remaining positions, they are removed from the chart.
 	</p>
 
 	<p>
-		Use the 
+		Use the
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
 			<path
 				d="M19.14 12.94c.04-.31.06-.63.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.64l-1.92-3.32a.5.5 0 0 0-.6-.22l-2.39.96a7.28 7.28 0 0 0-1.63-.94l-.36-2.54A.5.5 0 0 0 13.9 2h-3.8a.5.5 0 0 0-.49.42l-.36 2.54c-.58.22-1.13.54-1.63.94l-2.39-.96a.5.5 0 0 0-.6.22L2.71 8.48a.5.5 0 0 0 .12.64l2.03 1.58c-.04.31-.06.63-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.64l1.92 3.32a.5.5 0 0 0 .6.22l2.39-.96c.5.4 1.05.72 1.63.94l.36 2.54a.5.5 0 0 0 .49.42h3.8a.5.5 0 0 0 .49-.42l.36-2.54c.58-.22 1.13-.54 1.63-.94l2.39.96a.5.5 0 0 0 .6-.22l1.92-3.32a.5.5 0 0 0-.12-.64l-2.03-1.58zM12 15.5A3.5 3.5 0 1 1 12 8.5a3.5 3.5 0 0 1 0 7z"
 			/>
 		</svg>
-		icon in the header to open Settings. From there you can turn on Show Secondary
-		Positions to include secondary roles in the lists, and toggle the
-		<TermTooltip
-			label="Player Skill Colour Gradient"
-			tooltip_id="skill-gradient-tooltip-how-to"
-		>
+		icon in the header to open Settings. From there you can turn on Show Secondary Positions to include
+		secondary roles in the lists, and toggle the
+		<TermTooltip label="Player Skill Colour Gradient" tooltip_id="skill-gradient-tooltip-how-to">
 			a subtle colour on each player row based on skill level:
 			<span class="tooltip-skill-high">high</span>,
 			<span class="tooltip-skill-mid">mid</span>, and
@@ -83,12 +79,30 @@
 		</TermTooltip>
 		on or off. Depth totals and header colours always use primary positions only.
 	</p>
-	
+
+	<h2>Sorting</h2>
+	<p>Open Settings and choose a Sort Mode for player lists:</p>
+	<div class="depth-legend" aria-label="Sort mode options">
+		<div class="depth-item">
+			<div>
+				<strong>Default</strong>
+				<p>Groups primary players above secondary players, then uses list order.</p>
+			</div>
+		</div>
+		<div class="depth-item">
+			<div>
+				<strong>Custom</strong>
+				<p>Uses your manual list order only, so any player can be moved anywhere.</p>
+			</div>
+		</div>
+	</div>
+
 	<h2>Depth & Colours</h2>
 
 	<p>
-		The header fraction is: primary players in that position / target depth for the formation. Target
-		depth is twice the starting requirement (for example, a two-CB formation targets four total CBs).
+		The header fraction is: primary players in that position / target depth for the formation.
+		Target depth is twice the starting requirement (for example, a two-CB formation targets four
+		total CBs).
 	</p>
 
 	<div class="depth-legend" aria-label="Depth colour legend">
@@ -138,8 +152,8 @@
 	</div>
 
 	<p>
-		Use Share Image to download a PNG of the position grid. Clear All Players will remove everyone after
-		confirmation. Your depth chart is saved automatically in this browser.
+		Use Share Image to download a PNG of the position grid. Clear All Players will remove everyone
+		after confirmation. Your depth chart is saved automatically in this browser.
 	</p>
 </section>
 

--- a/src/routes/PlayerList.svelte
+++ b/src/routes/PlayerList.svelte
@@ -15,7 +15,12 @@
 	} from "$lib/player_list_item";
 	import { getVisibleAssignedPosition } from "$lib/player_visibility";
 	import { formation } from "$lib/stores/formation_store";
-	import { players, removePlayer, type PlayerRecord, updatePlayers } from "$lib/stores/player_store";
+	import {
+		players,
+		removePlayer,
+		type PlayerRecord,
+		updatePlayers,
+	} from "$lib/stores/player_store";
 	import { settings } from "$lib/stores/settings_store";
 	import PlayerEditModal from "./PlayerEditModal.svelte";
 	import { flip } from "svelte/animate";
@@ -24,7 +29,9 @@
 	export let removesItems = false;
 	export let show_secondary_positions = false;
 
-	$: visible_positions = new Set(getPositionSelectOptions($formation).map((option) => option.value));
+	$: visible_positions = new Set(
+		getPositionSelectOptions($formation).map((option) => option.value),
+	);
 
 	$: filtered_players = $players
 		.filter((player) => {
@@ -33,7 +40,7 @@
 			}
 			return getVisibleAssignedPosition(player, visible_positions) === position;
 		})
-		.toSorted((a, b) => comparePlayersForPosition(a, b, position));
+		.toSorted((a, b) => comparePlayersForPosition(a, b, position, $settings.player_sort_mode));
 
 	let ghost: HTMLElement;
 	let grabbed: HTMLElement | null = null;
@@ -100,20 +107,10 @@
 		filtered_players = [...filtered_players.slice(0, from), ...filtered_players.slice(from + 1)];
 		filtered_players = [...filtered_players.slice(0, to), temp, ...filtered_players.slice(to)];
 
-		const updated_player_weights = filtered_players.map((plyr, idx) => {
-			const updated_plyr = {
-				name: plyr.name,
-				positions: plyr.positions.map((pos) => {
-					if (pos.position === position) {
-						return { position, weight: idx };
-					} else {
-						return pos;
-					}
-				}),
-			};
-
-			return updated_plyr;
-		});
+		const updated_player_weights = filtered_players.map((plyr, idx) => ({
+			name: plyr.name,
+			positions: [{ position, weight: idx }],
+		}));
 
 		updatePlayers(updated_player_weights);
 	}
@@ -301,7 +298,11 @@
 	</section>
 </main>
 
-<PlayerEditModal open={show_edit_modal} playerName={editing_player_name} on:close={closeEditModal} />
+<PlayerEditModal
+	open={show_edit_modal}
+	playerName={editing_player_name}
+	on:close={closeEditModal}
+/>
 
 <style>
 	main {

--- a/src/routes/SettingsModal.svelte
+++ b/src/routes/SettingsModal.svelte
@@ -44,6 +44,37 @@
 				<button class="modal-close" aria-label="Close settings" on:click={close}>×</button>
 			</header>
 			<div class="modal-body">
+				<label class="setting-row" for="player-sort-mode">
+					<div>
+						<span class="setting-title setting-title-inline">
+							<span>Sort Mode</span>
+							<span class="setting-info-icon">
+								<TermTooltip label="i" tooltip_id="sort-mode-tooltip-settings">
+									Default keeps players grouped by role (primary before secondary), then orders by
+									list position. Custom uses your manual list order only, so you can place players
+									anywhere.
+								</TermTooltip>
+							</span>
+						</span>
+						<span class="setting-copy"
+							>Choose how players are ordered within each position list.</span
+						>
+					</div>
+					<select
+						id="player-sort-mode"
+						class="setting-select"
+						aria-label="Sort Mode"
+						value={$settings.player_sort_mode}
+						on:change={(event) => {
+							const target = event.currentTarget as HTMLSelectElement;
+							updateSetting("player_sort_mode", target.value as AppSettings["player_sort_mode"]);
+						}}
+					>
+						<option value="default">Default (Skill)</option>
+						<option value="custom">Custom (Manual)</option>
+					</select>
+				</label>
+
 				<label class="setting-row" for="show-skill-gradient">
 					<div>
 						<span class="setting-title">
@@ -176,6 +207,36 @@
 	.setting-title {
 		display: block;
 		font-weight: 600;
+	}
+
+	.setting-title-inline {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.setting-info-icon :global(.tooltip-trigger) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.05rem;
+		height: 1.05rem;
+		border-radius: 999px;
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-decoration: none;
+		background: hsl(210, 24%, 90%);
+		color: hsl(210, 40%, 28%);
+	}
+
+	.setting-select {
+		min-width: 175px;
+		padding: 0.35rem 0.45rem;
+		border-radius: 8px;
+		border: 1px solid var(--panel-border);
+		background: var(--white);
+		color: var(--text-dark);
+		font-size: 0.9rem;
 	}
 
 	.setting-copy {

--- a/tests/unit/lib/player_list_item.test.ts
+++ b/tests/unit/lib/player_list_item.test.ts
@@ -32,7 +32,9 @@ describe("player_list_item", () => {
 
 	it("uses configured skill for secondary role with mid fallback", () => {
 		expect(getSkillForPosition(player("A", "secondary", 1, "low"), Position.CentreMid)).toBe("low");
-		expect(getSkillForPosition(player("B", "secondary", 1, "high"), Position.CentreMid)).toBe("high");
+		expect(getSkillForPosition(player("B", "secondary", 1, "high"), Position.CentreMid)).toBe(
+			"high",
+		);
 		expect(getSkillForPosition(player("C", "secondary", 1), Position.CentreMid)).toBe("mid");
 	});
 
@@ -48,5 +50,23 @@ describe("player_list_item", () => {
 		const b = player("B", "secondary", 3);
 		expect(comparePlayersForPosition(a, b, Position.CentreMid)).toBeLessThan(0);
 		expect(comparePlayersForPosition(b, a, Position.CentreMid)).toBeGreaterThan(0);
+	});
+
+	it("sorts by weight only in custom mode", () => {
+		const primary = player("A", "primary", 9);
+		const secondary = player("B", "secondary", 0);
+		expect(
+			comparePlayersForPosition(primary, secondary, Position.CentreMid, "custom"),
+		).toBeGreaterThan(0);
+		expect(
+			comparePlayersForPosition(secondary, primary, Position.CentreMid, "custom"),
+		).toBeLessThan(0);
+	});
+
+	it("uses name as a tie-breaker in custom mode", () => {
+		const a = player("A", "secondary", 1);
+		const b = player("B", "secondary", 1);
+		expect(comparePlayersForPosition(a, b, Position.CentreMid, "custom")).toBeLessThan(0);
+		expect(comparePlayersForPosition(b, a, Position.CentreMid, "custom")).toBeGreaterThan(0);
 	});
 });

--- a/tests/unit/routes/PlayerList.test.ts
+++ b/tests/unit/routes/PlayerList.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import PlayerList from "../../../src/routes/PlayerList.svelte";
+import { Position } from "$lib/positions";
+import { Formation, formation } from "$lib/stores/formation_store";
+import { players } from "$lib/stores/player_store";
+import { settings } from "$lib/stores/settings_store";
+
+describe("PlayerList", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		formation.set(Formation.FourFourTwo);
+		players.set([]);
+		settings.set({
+			show_skill_gradient: true,
+			show_secondary_positions: true,
+			player_sort_mode: "custom",
+		});
+	});
+
+	it("lets a secondary-position player move above primary-position players in custom sort mode", async () => {
+		players.set([
+			{
+				name: "Primary CM",
+				positions: [{ position: Position.CentreMid, weight: 0, role: "primary" }],
+			},
+			{
+				name: "Secondary CM",
+				positions: [
+					{ position: Position.Striker, weight: 0, role: "primary" },
+					{ position: Position.CentreMid, weight: 1, role: "secondary", skill: "mid" },
+				],
+			},
+		]);
+
+		const { container } = render(PlayerList, {
+			position: Position.CentreMid,
+			removesItems: false,
+			show_secondary_positions: true,
+		});
+
+		const getOrder = (): string[] =>
+			Array.from(container.querySelectorAll("section.list [role='listitem'] .player-name")).map(
+				(node) => node.textContent?.trim() ?? "",
+			);
+
+		expect(getOrder()).toEqual(["Primary CM", "Secondary CM"]);
+
+		await userEvent.click(screen.getByRole("button", { name: "Move Secondary CM up" }));
+
+		await waitFor(() => {
+			expect(getOrder()).toEqual(["Secondary CM", "Primary CM"]);
+		});
+	});
+});

--- a/tests/unit/routes/SettingsModal.test.ts
+++ b/tests/unit/routes/SettingsModal.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/svelte";
+import { get } from "svelte/store";
+import SettingsModal from "../../../src/routes/SettingsModal.svelte";
+import { settings } from "$lib/stores/settings_store";
+
+describe("SettingsModal", () => {
+	beforeEach(() => {
+		settings.set({
+			show_skill_gradient: true,
+			show_secondary_positions: false,
+			player_sort_mode: "default",
+		});
+	});
+
+	it("shows sort mode select and its helper tooltip copy", () => {
+		render(SettingsModal, { open: true });
+
+		expect(screen.getByLabelText("Sort Mode")).toBeTruthy();
+		expect(screen.getByText(/Default keeps players grouped by role/)).toBeTruthy();
+	});
+
+	it("updates sort mode in settings when the select changes", async () => {
+		render(SettingsModal, { open: true });
+		const select = screen.getByLabelText("Sort Mode") as HTMLSelectElement;
+
+		await userEvent.selectOptions(select, "custom");
+
+		expect(get(settings).player_sort_mode).toBe("custom");
+	});
+});

--- a/tests/unit/routes/page.test.ts
+++ b/tests/unit/routes/page.test.ts
@@ -15,6 +15,7 @@ describe("+page", () => {
 		settings.set({
 			show_skill_gradient: true,
 			show_secondary_positions: false,
+			player_sort_mode: "default",
 		});
 	});
 


### PR DESCRIPTION
## Summary
- add a new player_sort_mode setting with persisted default/custom values
- update player list sorting to support default (skill/role-aware) and custom (manual weight-only) modes
- add a Sort Mode select in Settings with an info tooltip and updated option labels
- add a Sorting section to the How To Use content
- add regression tests for custom sort behaviour and settings mode updates

## Testing
- pnpm test