### PR TITLE
Fix tooltip clipping and improve How To Use mobile UX

### DIFF
--- a/src/lib/TermTooltip.svelte
+++ b/src/lib/TermTooltip.svelte
@@ -1,12 +1,210 @@
 <script lang="ts">
+	import { onDestroy, tick } from "svelte";
+
 	export let label: string;
 	export let tooltip_id: string;
 	export let description = "";
+
+	let wrap_el: HTMLSpanElement | null = null;
+	let trigger_el: HTMLSpanElement | null = null;
+	let bubble_el: HTMLSpanElement | null = null;
+	let open = false;
+	let placement: "top" | "bottom" = "top";
+	let bubble_style = "";
+	let has_coarse_pointer = false;
+	let media_query: MediaQueryList | null = null;
+
+	const TOOLTIP_GAP_PX = 8;
+	const EDGE_GUTTER_PX = 8;
+
+	function setupPointerMode(): void {
+		if (typeof window === "undefined" || !window.matchMedia) {
+			return;
+		}
+
+		media_query = window.matchMedia("(hover: none), (pointer: coarse)");
+		has_coarse_pointer = media_query.matches;
+		media_query.addEventListener("change", onPointerModeChange);
+	}
+
+	function onPointerModeChange(event: MediaQueryListEvent): void {
+		has_coarse_pointer = event.matches;
+	}
+
+	async function updateTooltipPosition(): Promise<void> {
+		if (!open || !trigger_el || !bubble_el || typeof window === "undefined") {
+			return;
+		}
+
+		await tick();
+
+		const trigger_rect = trigger_el.getBoundingClientRect();
+		const bubble_rect = bubble_el.getBoundingClientRect();
+		const viewport_width = window.innerWidth;
+		const viewport_height = window.innerHeight;
+		const max_left = Math.max(EDGE_GUTTER_PX, viewport_width - EDGE_GUTTER_PX - bubble_rect.width);
+		const centred_left = trigger_rect.left + trigger_rect.width / 2 - bubble_rect.width / 2;
+		const left = Math.min(Math.max(centred_left, EDGE_GUTTER_PX), max_left);
+		const top_candidate = trigger_rect.top - TOOLTIP_GAP_PX - bubble_rect.height;
+		const bottom_candidate = trigger_rect.bottom + TOOLTIP_GAP_PX;
+
+		placement = top_candidate >= EDGE_GUTTER_PX ? "top" : "bottom";
+		let top = placement === "top" ? top_candidate : bottom_candidate;
+		top = Math.min(
+			Math.max(top, EDGE_GUTTER_PX),
+			Math.max(EDGE_GUTTER_PX, viewport_height - EDGE_GUTTER_PX - bubble_rect.height),
+		);
+
+		bubble_style = `left: ${Math.round(left)}px; top: ${Math.round(top)}px;`;
+	}
+
+	function openTooltip(): void {
+		if (open) {
+			void updateTooltipPosition();
+			return;
+		}
+
+		open = true;
+		void updateTooltipPosition();
+	}
+
+	function closeTooltip(): void {
+		open = false;
+	}
+
+	function onPointerEnter(): void {
+		if (!has_coarse_pointer) {
+			openTooltip();
+		}
+	}
+
+	function onPointerLeave(): void {
+		if (!has_coarse_pointer) {
+			closeTooltip();
+		}
+	}
+
+	function onTriggerFocus(): void {
+		openTooltip();
+	}
+
+	function onTriggerBlur(): void {
+		closeTooltip();
+	}
+
+	function onTriggerClick(event: MouseEvent): void {
+		if (!has_coarse_pointer) {
+			return;
+		}
+
+		event.preventDefault();
+		if (open) {
+			closeTooltip();
+			return;
+		}
+
+		openTooltip();
+	}
+
+	function onKeyDown(event: KeyboardEvent): void {
+		if (event.key === "Escape") {
+			closeTooltip();
+		}
+	}
+
+	function onGlobalPointerDown(event: PointerEvent): void {
+		if (!open) {
+			return;
+		}
+
+		const target = event.target;
+		if (!(target instanceof Node)) {
+			closeTooltip();
+			return;
+		}
+
+		if (wrap_el?.contains(target) || bubble_el?.contains(target)) {
+			return;
+		}
+
+		closeTooltip();
+	}
+
+	function onWindowChange(): void {
+		if (!open) {
+			return;
+		}
+
+		void updateTooltipPosition();
+	}
+
+	function portal(node: HTMLElement): { destroy: () => void } {
+		if (typeof document === "undefined") {
+			return {
+				destroy() {},
+			};
+		}
+
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			},
+		};
+	}
+
+	$: if (typeof window !== "undefined") {
+		void updateTooltipPosition();
+	}
+
+	if (typeof window !== "undefined") {
+		setupPointerMode();
+		window.addEventListener("resize", onWindowChange);
+		window.addEventListener("scroll", onWindowChange, true);
+		window.addEventListener("orientationchange", onWindowChange);
+		document.addEventListener("pointerdown", onGlobalPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+	}
+
+	onDestroy(() => {
+		media_query?.removeEventListener("change", onPointerModeChange);
+		if (typeof window !== "undefined") {
+			window.removeEventListener("resize", onWindowChange);
+			window.removeEventListener("scroll", onWindowChange, true);
+			window.removeEventListener("orientationchange", onWindowChange);
+			document.removeEventListener("pointerdown", onGlobalPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		}
+	});
 </script>
 
-<span class="tooltip-wrap">
-	<span class="tooltip-trigger" tabindex="0" aria-describedby={tooltip_id}>{label}</span>
-	<span class="tooltip-bubble" role="tooltip" id={tooltip_id}>
+<span
+	class="tooltip-wrap"
+	bind:this={wrap_el}
+>
+	<button
+		type="button"
+		class="tooltip-trigger"
+		aria-describedby={tooltip_id}
+		bind:this={trigger_el}
+		on:mouseenter={onPointerEnter}
+		on:mouseleave={onPointerLeave}
+		on:focus={onTriggerFocus}
+		on:blur={onTriggerBlur}
+		on:click={onTriggerClick}
+	>
+		{label}
+	</button>
+	<span
+		class="tooltip-bubble"
+		class:is-open={open}
+		class:is-bottom={placement === "bottom"}
+		role="tooltip"
+		id={tooltip_id}
+		bind:this={bubble_el}
+		style={bubble_style}
+		use:portal
+	>
 		<slot>{description}</slot>
 	</span>
 </span>
@@ -19,6 +217,9 @@
 
 	.tooltip-trigger {
 		display: inline;
+		padding: 0;
+		border: none;
+		background: transparent;
 		color: color-mix(in srgb, var(--text-dark) 86%, var(--primary));
 		font-weight: 500;
 		text-decoration-line: underline;
@@ -47,11 +248,9 @@
 	}
 
 	.tooltip-bubble {
-		position: absolute;
-		left: 50%;
-		bottom: calc(100% + 0.45rem);
-		transform: translate(-50%, 6px);
-		width: min(22rem, 85vw);
+		position: fixed;
+		transform: translateY(6px);
+		max-width: min(22rem, calc(100vw - 1rem - env(safe-area-inset-left) - env(safe-area-inset-right)));
 		padding: 0.6rem 0.7rem;
 		border-radius: 10px;
 		border: var(--border);
@@ -64,12 +263,22 @@
 		pointer-events: none;
 		transition: opacity 0.15s ease, transform 0.15s ease;
 		z-index: 1105;
+		overflow-wrap: break-word;
 	}
 
-	.tooltip-wrap:hover .tooltip-bubble,
-	.tooltip-wrap:focus-within .tooltip-bubble {
+	.tooltip-bubble.is-open {
 		opacity: 1;
-		transform: translate(-50%, 0);
+		transform: translateY(0);
+	}
+
+	.tooltip-bubble.is-open.is-bottom {
+		transform: translateY(0);
+	}
+
+	@media (pointer: coarse) {
+		.tooltip-trigger {
+			cursor: pointer;
+		}
 	}
 
 	:global(.tooltip-skill-high) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,6 +36,15 @@
 			<button type="button" class="help-link" on:click={openHowToUseModal}>How to Use</button>
 			<button
 				type="button"
+				class="help-icon-link"
+				aria-label="How to Use"
+				title="How to Use"
+				on:click={openHowToUseModal}
+			>
+				?
+			</button>
+			<button
+				type="button"
 				class="settings-link"
 				aria-label="Settings"
 				title="Settings"
@@ -120,6 +129,34 @@
 		color: var(--accent);
 	}
 
+	.help-icon-link {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		width: 1.35rem;
+		height: 1.35rem;
+		padding: 0;
+		border-radius: 999px;
+		border: 1px solid rgba(255, 255, 255, 0.45);
+		background: rgba(255, 255, 255, 0.16);
+		color: var(--text-light);
+		font-size: 0.86rem;
+		font-weight: 700;
+		line-height: 1;
+		cursor: pointer;
+		transition:
+			background-color 0.2s ease,
+			border-color 0.2s ease,
+			color 0.2s ease;
+	}
+
+	.help-icon-link:hover,
+	.help-icon-link:focus {
+		background: rgba(255, 255, 255, 0.28);
+		border-color: rgba(255, 255, 255, 0.62);
+		color: var(--accent);
+	}
+
 	a {
 		color: var(--text-light);
 		text-decoration: none;
@@ -189,7 +226,7 @@
 
 	@media screen and (max-width: 700px) {
 		div.header-content {
-			padding: 0 5px;
+			padding: 0.7rem var(--side);
 		}
 
 		#footer-content {
@@ -203,6 +240,10 @@
 
 		div.header-controls .help-link {
 			display: none;
+		}
+
+		div.header-controls .help-icon-link {
+			display: inline-flex;
 		}
 	}
 </style>

--- a/src/routes/HowToUseContent.svelte
+++ b/src/routes/HowToUseContent.svelte
@@ -269,8 +269,18 @@
 		background-color: var(--paper);
 		padding: 1.2rem;
 		border-radius: var(--border-radius);
+		width: 100%;
 		max-width: var(--column);
-		border: var(--border);
+		margin-inline: auto;
+		box-sizing: border-box;
+		overflow-x: clip;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.how-to-use-content > * {
+		min-width: 0;
+		max-width: 100%;
 	}
 
 	.how-to-use-content h1 {
@@ -284,6 +294,11 @@
 
 	.how-to-use-content p {
 		margin-top: 0.4rem;
+		overflow-wrap: anywhere;
+	}
+
+	.how-to-use-content > p:last-child {
+		margin-bottom: 0.9rem;
 	}
 
 	.intro {
@@ -294,6 +309,18 @@
 		display: grid;
 		gap: 0.7rem;
 		grid-template-columns: repeat(3, minmax(0, 1fr));
+		width: 100%;
+		min-width: 0;
+		height: auto;
+		overflow: visible;
+		border: 0;
+		outline: 0;
+		max-width: 100%;
+	}
+
+	.quick-start-grid > * {
+		min-width: 0;
+		max-width: 100%;
 	}
 
 	.step-card {
@@ -301,6 +328,9 @@
 		border-radius: 10px;
 		padding: 0.8rem;
 		background: linear-gradient(160deg, hsl(0, 0%, 100%), hsl(210, 18%, 97%));
+		min-width: 0;
+		width: 100%;
+		box-sizing: border-box;
 	}
 
 	.step-number {
@@ -341,6 +371,7 @@
 		gap: 0.45rem;
 		background-color: var(--white);
 		font-size: 0.88rem;
+		min-width: 0;
 	}
 
 	.chip-icon {
@@ -349,6 +380,7 @@
 		justify-content: center;
 		min-width: 1.25rem;
 		height: 1.25rem;
+		flex-shrink: 0;
 		border-radius: 999px;
 		background: hsl(210, 26%, 91%);
 		font-weight: 700;
@@ -359,6 +391,11 @@
 	.chip-icon svg {
 		display: block;
 		fill: currentColor;
+	}
+
+	.action-chip > span:last-child {
+		min-width: 0;
+		overflow-wrap: anywhere;
 	}
 
 	.depth-legend {
@@ -374,6 +411,7 @@
 		padding: 0.65rem 0.75rem;
 		border: 1px solid transparent;
 		border-radius: 10px;
+		min-width: 0;
 	}
 
 	.depth-item p {
@@ -596,6 +634,7 @@
 	.row-demo-note-text {
 		display: inline;
 		min-width: 0;
+		overflow-wrap: anywhere;
 	}
 
 	.row-demo-inline-note :global(.tooltip-trigger) {
@@ -618,7 +657,15 @@
 	}
 
 	@media screen and (max-width: 900px) {
-		.quick-start-grid,
+		.how-to-use-content {
+			padding: 1rem;
+		}
+
+		.quick-start-grid {
+			display: flex;
+			flex-direction: column;
+		}
+
 		.action-strip {
 			grid-template-columns: 1fr;
 		}
@@ -634,6 +681,27 @@
 
 		.row-demo-control {
 			align-items: flex-start;
+		}
+
+		.action-chip {
+			border-radius: 12px;
+			align-items: flex-start;
+		}
+	}
+
+	@media screen and (max-width: 1080px) {
+		.quick-start-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media screen and (max-width: 560px) {
+		.how-to-use-content {
+			padding: 0.85rem;
+		}
+
+		.row-demo {
+			padding: 0.65rem;
 		}
 	}
 </style>

--- a/src/routes/HowToUseContent.svelte
+++ b/src/routes/HowToUseContent.svelte
@@ -1,5 +1,24 @@
 <script lang="ts">
 	import TermTooltip from "$lib/TermTooltip.svelte";
+
+	type SkillLevel = "low" | "mid" | "high";
+
+	let demo_skill: SkillLevel = "mid";
+	let demo_show_gradient = true;
+	let demo_show_secondary = true;
+
+	function getSkillColour(skill: SkillLevel): string {
+		if (skill === "low") return "hsl(8 78% 56%)";
+		if (skill === "high") return "hsl(120 52% 45%)";
+		return "hsl(46 92% 54%)";
+	}
+
+	function getSkillFadeColour(skill: SkillLevel): string {
+		if (skill === "low") return "hsl(8 78% 56% / 0)";
+		if (skill === "high") return "hsl(120 52% 45% / 0)";
+		return "hsl(46 92% 54% / 0)";
+	}
+
 </script>
 
 <section class="how-to-use-content">
@@ -132,6 +151,90 @@
 			</div>
 		</div>
 	</div>
+
+	<h2>Reading Player Rows</h2>
+	<p>
+		Use this demo row to see what each visual cue means. Change the options to preview how settings affect
+		what you see in each position list.
+	</p>
+	<section class="row-demo" aria-label="Player row demo">
+		<div class="row-demo-controls">
+			<label class="row-demo-control">
+				<span>Skill Level</span>
+				<select
+					class="row-demo-skill-select"
+					bind:value={demo_skill}
+					aria-label="Demo skill level"
+					style={`--skill-color: ${getSkillColour(demo_skill)}`}
+				>
+					<option value="high">High</option>
+					<option value="mid">Mid</option>
+					<option value="low">Low</option>
+				</select>
+			</label>
+			<label class="row-demo-toggle">
+				<input type="checkbox" bind:checked={demo_show_gradient} />
+				<span>Show skill gradient</span>
+			</label>
+			<label class="row-demo-toggle">
+				<input type="checkbox" bind:checked={demo_show_secondary} />
+				<span>Show secondary pill</span>
+			</label>
+		</div>
+
+		<article
+			class="demo-item"
+			class:demo-item-secondary={demo_show_secondary}
+			class:demo-item-has-skill-gradient={demo_show_gradient}
+			style={`--skill-color: ${getSkillColour(demo_skill)}; --skill-fade-color: ${getSkillFadeColour(demo_skill)};`}
+			data-testid="row-demo-item"
+		>
+			<div class="demo-buttons" aria-hidden="true">
+				<span></span>
+				<span></span>
+			</div>
+			<div class="demo-content">
+				<span class="player-name">Jordan Example</span>
+				<span class="meta-row">
+					<span class="pill role-pill role-primary">Primary: ST</span>
+					{#if demo_show_secondary}
+						<span class="pill role-pill role-secondary">2nd</span>
+					{/if}
+				</span>
+			</div>
+			<div class="demo-buttons actions" aria-hidden="true">
+				<span></span>
+				<span></span>
+			</div>
+		</article>
+
+		<div class="row-demo-notes" aria-label="Row cue legend">
+			<p class="row-demo-note-row">
+				<span class="row-demo-inline-note">
+					<TermTooltip label="i" tooltip_id="row-primary-pill-note-tooltip-how-to">
+						Only shown when a player appears under a secondary position
+					</TermTooltip>
+				</span>
+				<span class="row-demo-note-text"><strong>Primary: ST</strong> identifies the player’s main role.</span>
+			</p>
+			<p class="row-demo-note-row">
+				<span class="row-demo-inline-note">
+					<TermTooltip label="i" tooltip_id="row-secondary-pill-note-tooltip-how-to">
+						Only shown when a player appears under a secondary position
+					</TermTooltip>
+				</span>
+				<span class="row-demo-note-text"
+					><strong>2nd pill</strong> means this player is shown here as a secondary position.</span
+				>
+			</p>
+			<p class="row-demo-note-row">
+				<span class="row-demo-inline-note row-demo-inline-note--placeholder" aria-hidden="true">i</span>
+				<span class="row-demo-note-text"
+					><strong>Right-side gradient</strong> reflects skill level when enabled in Settings.</span
+				>
+			</p>
+		</div>
+	</section>
 
 	<h2>Sharing & Saving</h2>
 	<div class="action-strip" aria-label="Share and save actions">
@@ -313,6 +416,207 @@
 		background-color: var(--red);
 	}
 
+	.row-demo {
+		border: var(--border);
+		border-radius: 12px;
+		padding: 0.75rem;
+		background: linear-gradient(160deg, hsl(0, 0%, 100%), hsl(210, 18%, 97%));
+		display: grid;
+		gap: 0.7rem;
+	}
+
+	.row-demo-controls {
+		display: flex;
+		gap: 0.8rem;
+		flex-wrap: wrap;
+		align-items: flex-end;
+	}
+
+	.row-demo-control {
+		display: inline-flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		font-size: 0.88rem;
+		font-weight: 600;
+	}
+
+	.row-demo-skill-select {
+		appearance: none;
+		border-radius: 999px;
+		border: 1px solid transparent;
+		width: 34px;
+		height: 34px;
+		padding: 0;
+		min-width: 34px;
+		background: var(--skill-color);
+		box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--skill-color), #000 18%);
+		color: transparent;
+		text-indent: -999px;
+		cursor: pointer;
+	}
+
+	.row-demo-skill-select option {
+		background: var(--white);
+		color: var(--text-dark);
+	}
+
+	.row-demo-skill-select option:hover,
+	.row-demo-skill-select option:focus,
+	.row-demo-skill-select option:checked {
+		background: color-mix(in srgb, var(--skill-color), #fff 70%);
+		color: var(--text-dark);
+	}
+
+	.row-demo-skill-select:focus {
+		outline: 2px solid color-mix(in srgb, var(--skill-color), #000 35%);
+		outline-offset: 2px;
+	}
+
+	.row-demo-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		font-size: 0.88rem;
+	}
+
+	.demo-item {
+		box-sizing: border-box;
+		display: inline-flex;
+		width: 100%;
+		min-height: 2.2em;
+		background-color: var(--white);
+		border: 1px solid var(--panel-border);
+		border-radius: 10px;
+		padding: 0.15rem 0.25rem;
+		position: relative;
+		overflow: hidden;
+		isolation: isolate;
+	}
+
+	.demo-item::after {
+		content: "";
+		position: absolute;
+		inset: 0 0 0 auto;
+		width: 36%;
+		background: linear-gradient(90deg, var(--skill-fade-color) 0%, var(--skill-color) 100%);
+		opacity: 0;
+		pointer-events: none;
+		z-index: 0;
+	}
+
+	.demo-item.demo-item-has-skill-gradient::after {
+		opacity: 0.35;
+	}
+
+	.demo-item.demo-item-secondary.demo-item-has-skill-gradient::after {
+		opacity: 0.22;
+	}
+
+	.demo-item > * {
+		margin: auto;
+		position: relative;
+		z-index: 1;
+	}
+
+	.demo-content {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.2rem;
+		padding: 0.12rem 0.25rem;
+	}
+
+	.demo-buttons {
+		width: 26px;
+		min-width: 26px;
+		display: flex;
+		flex-direction: column;
+		gap: 0.22rem;
+	}
+
+	.demo-buttons span {
+		display: block;
+		width: 14px;
+		height: 14px;
+		border-radius: 999px;
+		background: hsl(210, 22%, 87%);
+	}
+
+	.demo-buttons.actions span {
+		background: hsl(210, 22%, 82%);
+	}
+
+	.pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.05rem 0.4rem;
+		border-radius: 999px;
+		font-size: 0.68rem;
+		line-height: 1.15;
+		border: 1px solid transparent;
+		background: rgba(255, 255, 255, 0.75);
+	}
+
+	.role-pill.role-primary {
+		border-color: rgba(30, 58, 138, 0.2);
+		color: #1e3a8a;
+		background: rgba(219, 234, 254, 0.78);
+	}
+
+	.role-pill.role-secondary {
+		border-color: rgba(30, 64, 175, 0.28);
+		color: #1e40af;
+		background: rgba(219, 234, 254, 0.9);
+	}
+
+	.row-demo-notes {
+		display: grid;
+		gap: 0.4rem;
+		font-size: 0.88rem;
+	}
+
+	.row-demo-note-row {
+		margin: 0;
+		display: flex;
+		align-items: flex-start;
+		gap: 0.34rem;
+	}
+
+	.row-demo-inline-note {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 1.05rem;
+		width: 1.05rem;
+		height: 1.05rem;
+		margin-top: 0.05rem;
+	}
+
+	.row-demo-note-text {
+		display: inline;
+		min-width: 0;
+	}
+
+	.row-demo-inline-note :global(.tooltip-trigger) {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.05rem;
+		height: 1.05rem;
+		border-radius: 999px;
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-decoration: none;
+		background: hsl(210, 24%, 90%);
+		color: hsl(210, 40%, 28%);
+		line-height: 1;
+	}
+
+	.row-demo-inline-note--placeholder {
+		visibility: hidden;
+	}
+
 	@media screen and (max-width: 900px) {
 		.quick-start-grid,
 		.action-strip {
@@ -321,6 +625,15 @@
 
 		.depth-legend {
 			grid-template-columns: 1fr;
+		}
+
+		.row-demo-controls {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.row-demo-control {
+			align-items: flex-start;
 		}
 	}
 </style>

--- a/src/routes/HowToUseContent.svelte
+++ b/src/routes/HowToUseContent.svelte
@@ -87,7 +87,10 @@
 		<div class="depth-item">
 			<div>
 				<strong>Default</strong>
-				<p>Groups primary players above secondary players, then uses list order.</p>
+				<p>
+					Sorts players by skill, high to low, with primary positions above secondary when skill is 
+					equal.
+				</p>
 			</div>
 		</div>
 		<div class="depth-item">

--- a/src/routes/HowToUseModal.svelte
+++ b/src/routes/HowToUseModal.svelte
@@ -135,8 +135,30 @@
 	}
 
 	.modal-body {
-		padding: 1rem;
+		padding: 1rem 1rem 1.4rem;
 		overflow: auto;
 		min-height: 0;
+		display: flex;
+		justify-content: center;
+	}
+
+	@media screen and (max-width: 900px) {
+		.modal-backdrop {
+			padding: 0.6rem;
+		}
+
+		.modal-body {
+			padding: 0.7rem 0.7rem 1rem;
+		}
+	}
+
+	@media screen and (max-width: 560px) {
+		.modal-header {
+			padding: 0.75rem 0.8rem;
+		}
+
+		.modal-body {
+			padding: 0.55rem 0.55rem 0.85rem;
+		}
 	}
 </style>

--- a/src/routes/SettingsModal.svelte
+++ b/src/routes/SettingsModal.svelte
@@ -50,15 +50,13 @@
 							<span>Sort Mode</span>
 							<span class="setting-info-icon">
 								<TermTooltip label="i" tooltip_id="sort-mode-tooltip-settings">
-									Default keeps players grouped by role (primary before secondary), then orders by
-									list position. Custom uses your manual list order only, so you can place players
-									anywhere.
+									Default groups by skill and list order. Custom follows your manual order only.
 								</TermTooltip>
 							</span>
 						</span>
-						<span class="setting-copy"
-							>Choose how players are ordered within each position list.</span
-						>
+						<span class="setting-copy">
+							Choose how players are ordered within each position list.
+						</span>
 					</div>
 					<select
 						id="player-sort-mode"

--- a/tests/unit/lib/TermTooltip.test.ts
+++ b/tests/unit/lib/TermTooltip.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import TermTooltip from "../../../src/lib/TermTooltip.svelte";
+
+describe("TermTooltip", () => {
+	it("portals the tooltip to document.body and toggles on hover", async () => {
+		render(TermTooltip, {
+			label: "i",
+			tooltip_id: "tooltip-test",
+			description: "Tooltip copy",
+		});
+
+		const trigger = screen.getByText("i");
+		const tooltip = screen.getByRole("tooltip");
+
+		expect(tooltip.parentElement).toBe(document.body);
+		expect(tooltip.className.includes("is-open")).toBe(false);
+
+		await fireEvent.mouseEnter(trigger);
+		expect(tooltip.className.includes("is-open")).toBe(true);
+
+		await fireEvent.mouseLeave(trigger);
+		expect(tooltip.className.includes("is-open")).toBe(false);
+	});
+
+	it("supports tap toggling on coarse pointers", async () => {
+		const original_match_media = window.matchMedia;
+		window.matchMedia = vi.fn().mockReturnValue({
+			matches: true,
+			media: "(hover: none), (pointer: coarse)",
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		});
+
+		render(TermTooltip, {
+			label: "i",
+			tooltip_id: "tooltip-tap-test",
+			description: "Tooltip copy",
+		});
+
+		const trigger = screen.getByText("i");
+		const tooltip = screen.getByRole("tooltip");
+
+		await fireEvent.click(trigger);
+		expect(tooltip.className.includes("is-open")).toBe(true);
+
+		await fireEvent.click(trigger);
+		expect(tooltip.className.includes("is-open")).toBe(false);
+
+		window.matchMedia = original_match_media;
+	});
+});

--- a/tests/unit/routes/HowToUseContent.test.ts
+++ b/tests/unit/routes/HowToUseContent.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/svelte";
+import HowToUseContent from "../../../src/routes/HowToUseContent.svelte";
+
+describe("HowToUseContent", () => {
+	it("lets users preview player row cues with interactive controls", async () => {
+		render(HowToUseContent);
+
+		const demo_row = screen.getByTestId("row-demo-item");
+		const skill_select = screen.getByLabelText("Demo skill level");
+		const gradient_toggle = screen.getByLabelText("Show skill gradient");
+		const secondary_toggle = screen.getByLabelText("Show secondary pill");
+
+		expect(screen.getByText("Reading Player Rows")).toBeTruthy();
+		expect(screen.getByText("2nd")).toBeTruthy();
+		expect(demo_row.className.includes("demo-item-has-skill-gradient")).toBe(true);
+
+		await userEvent.selectOptions(skill_select, "high");
+		expect(demo_row.getAttribute("style")?.includes("hsl(120 52% 45%)")).toBe(true);
+		expect((skill_select as HTMLSelectElement).value).toBe("high");
+
+		await userEvent.click(secondary_toggle);
+		expect(screen.queryByText("2nd")).toBeNull();
+
+		await userEvent.click(gradient_toggle);
+		expect(demo_row.className.includes("demo-item-has-skill-gradient")).toBe(false);
+	});
+});

--- a/tests/unit/routes/SettingsModal.test.ts
+++ b/tests/unit/routes/SettingsModal.test.ts
@@ -18,7 +18,7 @@ describe("SettingsModal", () => {
 		render(SettingsModal, { open: true });
 
 		expect(screen.getByLabelText("Sort Mode")).toBeTruthy();
-		expect(screen.getByText(/Default keeps players grouped by role/)).toBeTruthy();
+		expect(screen.getByText(/Default groups by role and list order/)).toBeTruthy();
 	});
 
 	it("updates sort mode in settings when the select changes", async () => {

--- a/tests/unit/routes/SettingsModal.test.ts
+++ b/tests/unit/routes/SettingsModal.test.ts
@@ -18,7 +18,7 @@ describe("SettingsModal", () => {
 		render(SettingsModal, { open: true });
 
 		expect(screen.getByLabelText("Sort Mode")).toBeTruthy();
-		expect(screen.getByText(/Default groups by role and list order/)).toBeTruthy();
+		expect(screen.getByText(/Default groups by skill and list order/)).toBeTruthy();
 	});
 
 	it("updates sort mode in settings when the select changes", async () => {


### PR DESCRIPTION
## Summary
- fix tooltip clipping by rendering tooltips via a body portal with viewport-aware positioning
- add touch-friendly tooltip behaviour (tap toggle, outside-tap close, resize/scroll reposition)
- add an interactive "Reading Player Rows" demo in How To Use
- refine How To Use mobile layout for wrapping, spacing, and alignment
- add a mobile header question-mark help trigger to open How To Use
- adjust How To Use modal/content spacing and bottom padding

## Testing
- pnpm test (50 passing)