### PR TITLE
Improve chart responsiveness for mobile and tablet widths

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -95,7 +95,7 @@
 
 	<div id="position-boxes" class="position-boxes">
 		{#each positions as positionData}
-			<PositionBox positionData={positionData} show_secondary_positions={$settings.show_secondary_positions} />
+			<PositionBox {positionData} show_secondary_positions={$settings.show_secondary_positions} />
 		{/each}
 	</div>
 </div>
@@ -108,18 +108,23 @@
 
 <style>
 	div#content {
-		display: grid;
-		grid-template-columns: minmax(280px, 360px) 1fr;
+		display: flex;
+		flex-direction: column;
 		gap: 1.2rem;
 		margin: 0 auto;
 		max-width: var(--column);
-		padding: 1.2rem var(--side);
+		padding: 0.7rem 0;
+		width: 100%;
 	}
 
 	div#left-column {
 		display: flex;
 		flex-direction: column;
 		gap: 1.2rem;
+	}
+
+	div#left-column > * {
+		margin-inline: var(--side);
 	}
 
 	div.form-wrapper {
@@ -140,9 +145,10 @@
 	}
 
 	.position-boxes {
-		padding: 0.5rem 0.3rem 1rem;
+		padding: 0.4rem 0 0.9rem;
 		display: grid;
-		gap: 12px;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0.28rem;
 		grid-template-areas:
 			".. ST .."
 			"LW CAM RW"
@@ -217,17 +223,56 @@
 		border: 1px solid var(--panel-border);
 	}
 
-	@media screen and (max-width: 700px) {
+	@media screen and (min-width: 390px) {
+		.position-boxes {
+			gap: 0.4rem;
+		}
+	}
+
+	@media screen and (min-width: 768px) {
 		div#content {
-			display: flex;
-			flex-direction: column;
-			padding: 0.7rem var(--side);
+			padding: 0.9rem 0;
 		}
 
 		.position-boxes {
-			padding: 16px 0;
-			grid-gap: 10px;
-			margin-top: 10px;
+			padding: 0.45rem 0 1rem;
+			gap: 0.55rem;
+		}
+	}
+
+	@media screen and (min-width: 810px) {
+		div#content {
+			display: grid;
+			grid-template-columns: minmax(280px, 340px) 1fr;
+			align-items: start;
+			gap: 1rem;
+			padding: 1.1rem var(--side);
+		}
+
+		div#left-column > * {
+			margin-inline: 0;
+		}
+
+		.position-boxes {
+			padding: 0.5rem 0.2rem 1rem;
+			gap: 0.75rem;
+		}
+	}
+
+	@media screen and (min-width: 1366px) {
+		div#content {
+			grid-template-columns: minmax(300px, 360px) 1fr;
+			gap: 1.2rem;
+		}
+
+		.position-boxes {
+			gap: 0.85rem;
+		}
+	}
+
+	@media screen and (min-width: 1920px) {
+		.position-boxes {
+			gap: 1rem;
 		}
 	}
 </style>

--- a/src/routes/PlayerList.svelte
+++ b/src/routes/PlayerList.svelte
@@ -149,6 +149,11 @@
 		return getSkillForPosition(player, position);
 	}
 
+	function getPrimaryPosition(player: PlayerRecord): Position | null {
+		const primary_position = player.positions.find((pos) => pos.role === "primary");
+		return primary_position?.position ?? null;
+	}
+
 	function getSkillColor(skill: "low" | "mid" | "high"): string {
 		if (skill === "low") return "hsl(8 78% 56%)";
 		if (skill === "high") return "hsl(120 52% 45%)";
@@ -254,14 +259,17 @@
 					</button>
 				</div>
 
-				<div class="content">
-					<span class="player-name">{player.name}</span>
-					{#if isSecondary(player)}
-						<span class="meta-row">
-							<span class="pill role-pill role-secondary">2nd</span>
-						</span>
-					{/if}
-				</div>
+					<div class="content">
+						<span class="player-name">{player.name}</span>
+						{#if isSecondary(player)}
+							<span class="meta-row">
+								{#if getPrimaryPosition(player)}
+									<span class="pill role-pill role-primary">Primary: {getPrimaryPosition(player)}</span>
+								{/if}
+								<span class="pill role-pill role-secondary">2nd</span>
+							</span>
+						{/if}
+					</div>
 
 				<div class="buttons actions">
 					<button
@@ -401,6 +409,12 @@
 		border-color: rgba(30, 64, 175, 0.28);
 		color: #1e40af;
 		background: rgba(219, 234, 254, 0.9);
+	}
+
+	.role-pill.role-primary {
+		border-color: rgba(30, 58, 138, 0.2);
+		color: #1e3a8a;
+		background: rgba(219, 234, 254, 0.78);
 	}
 
 	.buttons {

--- a/src/routes/PlayerList.svelte
+++ b/src/routes/PlayerList.svelte
@@ -259,17 +259,19 @@
 					</button>
 				</div>
 
-					<div class="content">
-						<span class="player-name">{player.name}</span>
-						{#if isSecondary(player)}
-							<span class="meta-row">
-								{#if getPrimaryPosition(player)}
-									<span class="pill role-pill role-primary">Primary: {getPrimaryPosition(player)}</span>
-								{/if}
-								<span class="pill role-pill role-secondary">2nd</span>
-							</span>
-						{/if}
-					</div>
+				<div class="content">
+					<span class="player-name">{player.name}</span>
+					{#if isSecondary(player)}
+						<span class="meta-row">
+							{#if getPrimaryPosition(player)}
+								<span class="pill role-pill role-primary"
+									>Primary: {getPrimaryPosition(player)}</span
+								>
+							{/if}
+							<span class="pill role-pill role-secondary">2nd</span>
+						</span>
+					{/if}
+				</div>
 
 				<div class="buttons actions">
 					<button
@@ -333,7 +335,7 @@
 		background-color: var(--white);
 		border: 1px solid var(--panel-border);
 		border-radius: 10px;
-		padding: 0.15rem 0.25rem;
+		padding: 0.12rem 0.16rem;
 		user-select: none;
 		position: relative;
 		overflow: hidden;
@@ -379,12 +381,18 @@
 		flex-direction: column;
 		align-items: flex-start;
 		gap: 0.15rem;
-		padding: 0.1rem 0.25rem;
+		min-width: 0;
+		padding: 0.08rem 0.14rem;
 	}
 
 	.player-name {
+		display: block;
 		font-weight: 600;
 		line-height: 1.1;
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.meta-row {
@@ -397,9 +405,9 @@
 	.pill {
 		display: inline-flex;
 		align-items: center;
-		padding: 0.05rem 0.4rem;
+		padding: 0.03rem 0.26rem;
 		border-radius: 999px;
-		font-size: 0.68rem;
+		font-size: 0.56rem;
 		line-height: 1.15;
 		border: 1px solid transparent;
 		background: rgba(255, 255, 255, 0.75);
@@ -418,8 +426,8 @@
 	}
 
 	.buttons {
-		width: 32px;
-		min-width: 32px;
+		width: 24px;
+		min-width: 24px;
 		margin: auto 0;
 		display: flex;
 		flex-direction: column;
@@ -427,8 +435,8 @@
 
 	.buttons button {
 		cursor: pointer;
-		width: 18px;
-		height: 18px;
+		width: 20px;
+		height: 20px;
 		margin: 0 auto;
 		padding: 0;
 		border: 1px solid rgba(0, 0, 0, 0);
@@ -481,11 +489,47 @@
 		opacity: 1;
 	}
 
-	@media screen and (max-width: 700px) {
-		div.content {
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+	@media screen and (min-width: 390px) {
+		.pill {
+			font-size: 0.6rem;
+			padding: 0.04rem 0.3rem;
+		}
+
+		.buttons {
+			width: 26px;
+			min-width: 26px;
+		}
+
+		.buttons button {
+			width: 22px;
+			height: 22px;
+		}
+	}
+
+	@media screen and (min-width: 768px) {
+		.item {
+			padding: 0.18rem 0.3rem;
+		}
+
+		.pill {
+			font-size: 0.64rem;
+		}
+	}
+
+	@media screen and (min-width: 810px) {
+		.buttons {
+			width: 32px;
+			min-width: 32px;
+		}
+
+		.buttons button {
+			width: 22px;
+			height: 22px;
+		}
+
+		.pill {
+			font-size: 0.68rem;
+			padding: 0.05rem 0.4rem;
 		}
 
 		.meta-row {

--- a/src/routes/PositionBox.svelte
+++ b/src/routes/PositionBox.svelte
@@ -8,7 +8,9 @@
 	export let positionData: PositionData;
 	export let show_secondary_positions = false;
 
-	$: visible_positions = new Set(getPositionSelectOptions($formation).map((option) => option.value));
+	$: visible_positions = new Set(
+		getPositionSelectOptions($formation).map((option) => option.value),
+	);
 
 	$: primary_players = $players
 		.filter((plyr) => getVisibleAssignedPosition(plyr, visible_positions) === positionData.position)
@@ -71,13 +73,14 @@
 		border: var(--border);
 		border-radius: var(--border-radius);
 		background-color: var(--paper);
-		width: 300px;
-		min-height: 150px;
+		width: 100%;
+		min-width: 0;
+		min-height: 8.2rem;
 		box-shadow: var(--panel-shadow-soft);
 	}
 
 	div.position-header {
-		padding: 0.55rem 0.7rem;
+		padding: 0.38rem 0.34rem;
 		border-bottom: var(--border);
 		border-radius: var(--border-radius) var(--border-radius) 0 0;
 		font-weight: 600;
@@ -86,9 +89,22 @@
 	div.header-content {
 		display: flex;
 		justify-content: space-between;
-		gap: 5px;
+		gap: 0.35rem;
 		align-items: center;
-		font-size: 0.95rem;
+		font-size: clamp(0.58rem, 2.2vw, 0.9rem);
+	}
+
+	div.position-header span {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	div.depth-ratio {
+		font-size: clamp(0.53rem, 1.7vw, 0.78rem);
+		white-space: nowrap;
+		min-width: fit-content;
 	}
 
 	div.player-list {
@@ -96,21 +112,40 @@
 		height: 100%;
 	}
 
-	@media screen and (max-width: 700px) {
+	@media screen and (min-width: 390px) {
 		div.position-box-wrapper {
-			max-width: 132px;
-			font-size: 0.85rem;
+			min-height: 9rem;
+		}
+	}
+
+	@media screen and (min-width: 768px) {
+		div.position-box-wrapper {
+			width: 100%;
 		}
 
-		div.position-header span {
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+		div.position-header {
+			padding: 0.5rem 0.55rem;
+		}
+	}
+
+	@media screen and (min-width: 810px) {
+		div.position-box-wrapper {
+			min-height: 9.4rem;
+		}
+
+		div.header-content {
+			font-size: 0.9rem;
+			gap: 0.5rem;
 		}
 
 		div.depth-ratio {
-			font-size: 0.7rem;
-			min-width: fit-content;
+			font-size: 0.76rem;
+		}
+	}
+
+	@media screen and (min-width: 1366px) {
+		div.position-box-wrapper {
+			min-height: 9.8rem;
 		}
 	}
 </style>

--- a/src/styles.css
+++ b/src/styles.css
@@ -48,7 +48,7 @@ html {
 	--danger-button-bg-hover: hsl(6, 86%, 54%);
 
 	--column: 80rem;
-	--side: 1rem;
+	--side: 0.55rem;
 	--border: solid 1px var(--panel-border);
 	--debug-border: 1px dashed var(--red);
 	--border-radius: 12px;
@@ -69,6 +69,46 @@ body {
 	color: var(--text-dark);
 	letter-spacing: 0.1px;
 	line-height: 1.35;
+}
+
+@media screen and (min-width: 360px) {
+	html {
+		--side: 0.7rem;
+	}
+}
+
+@media screen and (min-width: 390px) {
+	html {
+		--side: 0.85rem;
+	}
+}
+
+@media screen and (min-width: 768px) {
+	html {
+		--column: 88rem;
+		--side: 1rem;
+	}
+}
+
+@media screen and (min-width: 810px) {
+	html {
+		--column: 92rem;
+		--side: 1.1rem;
+	}
+}
+
+@media screen and (min-width: 1366px) {
+	html {
+		--column: 106rem;
+		--side: 1.25rem;
+	}
+}
+
+@media screen and (min-width: 1920px) {
+	html {
+		--column: 120rem;
+		--side: 1.5rem;
+	}
 }
 
 button {

--- a/tests/unit/routes/PlayerList.test.ts
+++ b/tests/unit/routes/PlayerList.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen, waitFor } from "@testing-library/svelte";
+import { render, screen, waitFor, within } from "@testing-library/svelte";
 import PlayerList from "../../../src/routes/PlayerList.svelte";
 import { Position } from "$lib/positions";
 import { Formation, formation } from "$lib/stores/formation_store";
@@ -52,5 +52,10 @@ describe("PlayerList", () => {
 		await waitFor(() => {
 			expect(getOrder()).toEqual(["Secondary CM", "Primary CM"]);
 		});
+
+		const rows = container.querySelectorAll("section.list [role='listitem']");
+		expect(within(rows[0] as HTMLElement).getByText("Primary: ST")).toBeTruthy();
+		expect(within(rows[0] as HTMLElement).getByText("2nd")).toBeTruthy();
+		expect(within(rows[1] as HTMLElement).queryByText(/Primary:/)).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- commit existing PlayerList role-badge and unit-test updates
- refactor chart layout to be mobile-first and responsive at 360, 390, 768, 810, 1366, and 1920 widths
- tighten position-box and player-row spacing for portrait screens
- adjust global spacing tokens used by chart layout

## Validation
- pnpm test tests/unit/routes/PlayerList.test.ts
- pnpm prettier --check src/routes/+page.svelte src/routes/PositionBox.svelte src/routes/PlayerList.svelte src/styles.css